### PR TITLE
feat(progression): HP by difficulty mode (PHB average vs HardCore rolls)

### DIFF
--- a/core/character_storage.py
+++ b/core/character_storage.py
@@ -13,9 +13,13 @@ from core.subclasses import start_level_for_difficulty
 from core.types import GameDifficulty, StatMap
 
 
-def starting_max_hp(class_id: str, stats: StatMap) -> int:
-    """Максимум хитов на 1 уровне (PHB: max(1, кость + мод. Телосложения))."""
-    return max_hp_for_level(class_id, stats, 1)
+def starting_max_hp(
+    class_id: str,
+    stats: StatMap,
+    difficulty: GameDifficulty = "normal",
+) -> int:
+    """Максимум хитов на 1 уровне с учётом режима сложности."""
+    return max_hp_for_level(class_id, stats, 1, difficulty)
 
 
 def save_character(
@@ -38,7 +42,7 @@ def save_character(
         level = start_level_for_difficulty(difficulty)
     level = clamp_level(level)
 
-    hp = max_hp_for_level(class_id, stats, level)
+    hp = max_hp_for_level(class_id, stats, level, difficulty)
 
     character = Character(
         name=name,

--- a/core/progression.py
+++ b/core/progression.py
@@ -1,10 +1,10 @@
 """Прогрессия персонажа: опыт и уровни (PHB, макс. 10 уровень)."""
 
 from core.classes import get_class_hit_dice
-from core.dice import ability_modifier
+from core.dice import ability_modifier, roll
 from core.levels import MAX_CHARACTER_LEVEL, clamp_level
 from core.models import Character
-from core.types import StatMap
+from core.types import GameDifficulty, StatMap
 
 XP_THRESHOLDS: list[int] = [
     0,
@@ -29,16 +29,34 @@ def level_from_xp(experience: int) -> int:
     return min(level, MAX_CHARACTER_LEVEL)
 
 
-def max_hp_for_level(class_id: str, stats: StatMap, level: int) -> int:
-    """Максимум HP на заданном уровне (PHB average для 2+ уровней)."""
+def hp_gain_for_level(
+    level: int,
+    hit_dice: int,
+    con_mod: int,
+    difficulty: GameDifficulty = "normal",
+) -> int:
+    """Прирост максимальных HP за один уровень класса."""
+    if difficulty == "hardcore":
+        return roll(1, hit_dice) + con_mod
+    if level <= 1:
+        return max(1, hit_dice + con_mod)
+    return hit_dice // 2 + 1 + con_mod
+
+
+def max_hp_for_level(
+    class_id: str,
+    stats: StatMap,
+    level: int,
+    difficulty: GameDifficulty = "normal",
+) -> int:
+    """Максимум HP на заданном уровне с учётом режима сложности."""
     level = clamp_level(level)
     hit_dice = get_class_hit_dice(class_id)
     con_mod = ability_modifier(stats.get("constitution", 10))
-    first = max(1, hit_dice + con_mod)
-    if level <= 1:
-        return first
-    per_level = hit_dice // 2 + 1 + con_mod
-    return first + per_level * (level - 1)
+    total = 0
+    for lvl in range(1, level + 1):
+        total += hp_gain_for_level(lvl, hit_dice, con_mod, difficulty)
+    return total
 
 
 def apply_experience(character: Character, amount: int) -> Character:
@@ -49,13 +67,27 @@ def apply_experience(character: Character, amount: int) -> Character:
     old_level = character.level
     new_xp = character.experience + amount
     new_level = level_from_xp(new_xp)
-    new_max_hp = max_hp_for_level(
-        character.class_name, character.stats, new_level
-    )
 
     hp_gain = 0
     if new_level > old_level:
-        hp_gain = new_max_hp - character.max_hp
+        if character.difficulty == "hardcore":
+            hit_dice = get_class_hit_dice(character.class_name)
+            con_mod = ability_modifier(character.stats.get("constitution", 10))
+            for lvl in range(old_level + 1, new_level + 1):
+                hp_gain += hp_gain_for_level(
+                    lvl, hit_dice, con_mod, "hardcore"
+                )
+            new_max_hp = character.max_hp + hp_gain
+        else:
+            new_max_hp = max_hp_for_level(
+                character.class_name,
+                character.stats,
+                new_level,
+                character.difficulty,
+            )
+            hp_gain = new_max_hp - character.max_hp
+    else:
+        new_max_hp = character.max_hp
 
     return Character(
         name=character.name,

--- a/docs/API.md
+++ b/docs/API.md
@@ -86,8 +86,9 @@ CLASSES_FILE = Path("database/classes/classes.yaml")
 
 ```python
 save_character(...) -> Character
-starting_max_hp(class_id: str, stats: StatMap) -> int
-max_hp_at_level(class_id: str, stats: StatMap, level: int) -> int
+starting_max_hp(
+    class_id: str, stats: StatMap, difficulty: GameDifficulty = "normal"
+) -> int
 update_character(character: Character) -> Character
 load_characters() -> list[Character]
 load_races(language: str = "ru") -> list[dict[str, Any]]
@@ -117,9 +118,9 @@ validate_final_stats(stats: StatMap) -> tuple[str, int] | None
 ABILITY_SCORE_MAX = 20
 ```
 
-`save_character` создаёт `Character` (`current_hp` = `max_hp` = `max_hp_at_level(...)` с учётом режима сложности) и сохраняет в `saves/characters/{save_slug}.json`.  
-`starting_max_hp` — PHB: `max(1, hit_dice + ability_modifier(CON))` на 1 уровне.  
-`max_hp_at_level` — HP на заданном уровне (1–10).  
+`save_character` создаёт `Character` (`current_hp` = `max_hp` = `max_hp_for_level(..., difficulty)`) и сохраняет в `saves/characters/{save_slug}.json`.  
+`starting_max_hp` — HP на 1 уровне с учётом режима (Normal/Easy: `max(1, hit_dice + CON)`; HardCore: бросок + CON).  
+`max_hp_for_level` — см. `core.progression` (HP на уровне 1–10).  
 `update_character` — перезапись JSON после изменений (подкласс, XP и т.д.).
 `validate_final_stats` — первое превышение потолка 20 после всех бонусов; UI вызывает при финализации характеристик.
 
@@ -359,9 +360,22 @@ def effective_subclass_id(character: Character) -> str | None
 XP_THRESHOLDS: list[int]  # PHB, уровни 1–10
 
 def level_from_xp(experience: int) -> int
-def max_hp_for_level(class_id: str, stats: StatMap, level: int) -> int
+def hp_gain_for_level(
+    level: int,
+    hit_dice: int,
+    con_mod: int,
+    difficulty: GameDifficulty = "normal",
+) -> int
+def max_hp_for_level(
+    class_id: str,
+    stats: StatMap,
+    level: int,
+    difficulty: GameDifficulty = "normal",
+) -> int
 def apply_experience(character: Character, amount: int) -> Character
 ```
+
+**HP по режиму:** Normal/Easy — макс. кость на 1 ур., среднее на 2+; HardCore — бросок кости на каждом уровне. `apply_experience` для HardCore **добавляет** прирост за новые уровни, не пересчитывает `max_hp` по среднему.
 
 Re-export: `MAX_CHARACTER_LEVEL`, `clamp_level` из `core.levels`.
 

--- a/docs/rules/01-character-creation.md
+++ b/docs/rules/01-character-creation.md
@@ -19,13 +19,19 @@
 - Повышение уровня — по таблице опыта PHB (уровни **1–10** в MUD); см. `core/progression.py`.
 - Потолок уровня в игре: **10** (`MAX_CHARACTER_LEVEL`).
 
-### Хиты на 1 уровне
+### Хиты на 1 уровне (Normal / Easy)
 
 ```
 максимум хитов = максимум кости хитов класса + модификатор Телосложения
 ```
 
 Пример: воин (к10), Телосложение 14 (+2) → 10 + 2 = **12 HP**. Минимум на 1 уровне — **1 HP** (`max(1, …)`).
+
+### Хиты в HardCore
+
+На **каждом** уровне (включая 1-й): бросок кости хитов класса + модификатор Телосложения. На 1 уровне **без** нижней границы `max(1, …)` — возможны отрицательные итоги при низком Телосложении.
+
+При повышении уровня прирост фиксируется в `max_hp` и не пересчитывается задним числом.
 
 Текущие хиты не могут превышать максимум без особых эффектов (`max_hp` в модели `Character`).
 
@@ -72,7 +78,7 @@
 | Core | [`core/character_storage.py`](../../core/character_storage.py), [`core/stats.py`](../../core/stats.py), [`core/races.py`](../../core/races.py), [`core/classes.py`](../../core/classes.py), [`core/subclasses.py`](../../core/subclasses.py), [`core/progression.py`](../../core/progression.py) |
 | UI | [`ui/menus/character_flow.py`](../../ui/menus/character_flow.py), [`ui/menus/stats/`](../../ui/menus/stats/), [`ui/menus/settings.py`](../../ui/menus/settings.py) (`select_difficulty`), [`ui/menus/subclass_trainer.py`](../../ui/menus/subclass_trainer.py) |
 | Режимы | Normal / Easy: 3 метода + confirm; HardCore: `_select_stats_random_hardcore` |
-| Заметки | Предыстория, снаряжение, мультикласс — не в flow; HP = `max_hp_at_level()`; потолок характеристик — `ABILITY_SCORE_MAX` (20); потолок уровня — `MAX_CHARACTER_LEVEL` (10) |
+| Заметки | Предыстория, снаряжение, мультикласс — не в flow; HP = `max_hp_for_level(..., difficulty)`; потолок характеристик — `ABILITY_SCORE_MAX` (20); потолок уровня — `MAX_CHARACTER_LEVEL` (10) |
 
 ### Сохранение персонажа
 

--- a/docs/rules/03-classes.md
+++ b/docs/rules/03-classes.md
@@ -36,6 +36,15 @@
 
 На 1 уровне — максимум кости + модификатор Телосложения (см. [01-character-creation.md](01-character-creation.md)).
 
+#### Режимы в dnd_mud
+
+| Уровень | Normal / Easy | HardCore |
+|---------|---------------|----------|
+| 1 | `max(1, hit_dice + CON)` | бросок `hit_dice` + CON |
+| 2+ | среднее кости `(hit_dice // 2 + 1) + CON` | бросок `hit_dice` + CON |
+
+Среднее кости — PHB (для к10 → 6). Кость берётся из `hit_dice` в [`classes.yaml`](../../database/classes/classes.yaml).
+
 ### Заклинатели
 
 Бард, жрец, друид, следопыт (частично), чародей, колдун, волшебник — получают **ячейки заклинаний** по уровню. Механика — [10-spells.md](10-spells.md).
@@ -48,7 +57,7 @@
 
 | Аспект | Значение |
 |--------|----------|
-| Статус | Частично: 4 класса в YAML; выбор класса в UI; HP на 1 уровне |
+| Статус | Частично: 4 класса в YAML; выбор класса в UI; HP по режиму сложности |
 | YAML | [`database/classes/classes.yaml`](../../database/classes/classes.yaml) |
 | Core | [`core/classes.py`](../../core/classes.py): `load_classes()`, `get_class_hit_dice()` |
 | UI | [`ui/menus/character_flow.py`](../../ui/menus/character_flow.py) — шаг `_select_class` |
@@ -66,13 +75,16 @@
 
 Остальные 8 классов PHB — расширение каталога или моды.
 
-### Расчёт HP при создании
+### Расчёт HP
 
 ```python
-# core/character_storage.py
-hit_dice = get_class_hit_dice(class_id)
-hp = hit_dice + ability_modifier(stats["constitution"])
+# core/progression.py
+max_hp_for_level(class_id, stats, level, difficulty)
 ```
+
+- **Normal / Easy:** 1 ур. — `max(1, hit_dice + CON)`; 2+ — `(hit_dice // 2 + 1) + CON` за каждый уровень.
+- **HardCore:** на каждом уровне — `roll(1, hit_dice) + CON` (без пола на 1 ур.).
+- При левелапе HardCore прирост **добавляется** к текущему `max_hp` (`apply_experience`), не пересчитывается по среднему.
 
 ### Формат YAML (фрагмент)
 

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -160,7 +160,7 @@ def test_save_with_subclass_persisted(characters_dir):
 
 
 def test_starting_max_hp_floor_and_max_hp_field(characters_dir):
-    """HP на 1 уровне: max(1, кость + CON), current_hp == max_hp."""
+    """HP на 1 уровне (normal): max(1, кость + CON), current_hp == max_hp."""
     stats = {
         "strength": 10,
         "dexterity": 10,
@@ -174,11 +174,51 @@ def test_starting_max_hp_floor_and_max_hp_field(characters_dir):
         race_id="human",
         class_id="bard",
         stats=stats,
+        difficulty="normal",
     )
 
     assert saved.max_hp == 7
     assert saved.current_hp == saved.max_hp
     assert saved.max_hp >= 1
+
+
+def test_hardcore_creation_uses_rolls(characters_dir, monkeypatch):
+    """HardCore: HP при создании — сумма бросков кости по уровням."""
+    stats = dict.fromkeys(character_mod.STAT_NAMES, 10)
+    stats["constitution"] = 14
+
+    rolls_level1 = iter([5])
+
+    monkeypatch.setattr(
+        "core.progression.roll",
+        lambda count, sides, modifier=0: next(rolls_level1) + modifier,
+    )
+    saved = character_mod.save_character(
+        name="HardHero",
+        race_id="human",
+        class_id="fighter",
+        difficulty="hardcore",
+        stats=stats,
+    )
+    assert saved.level == 1
+    assert saved.max_hp == 7
+
+    rolls_level3 = iter([5, 8, 3])
+    monkeypatch.setattr(
+        "core.progression.roll",
+        lambda count, sides, modifier=0: next(rolls_level3) + modifier,
+    )
+    saved_level3 = character_mod.save_character(
+        name="HardLvl3",
+        race_id="human",
+        class_id="fighter",
+        difficulty="hardcore",
+        level=3,
+        stats=stats,
+        subclass_id="champion",
+    )
+    assert saved_level3.level == 3
+    assert saved_level3.max_hp == 22
 
 
 def test_validate_final_stats_rejects_over_20():

--- a/tests/test_progression.py
+++ b/tests/test_progression.py
@@ -2,7 +2,11 @@
 
 from core.levels import MAX_CHARACTER_LEVEL, clamp_level
 from core.models import Character
-from core.progression import apply_experience, level_from_xp
+from core.progression import (
+    apply_experience,
+    level_from_xp,
+    max_hp_for_level,
+)
 
 
 def test_max_character_level_is_ten():
@@ -22,6 +26,13 @@ def test_level_from_xp_does_not_exceed_cap():
     assert level_from_xp(999_999) == 10
 
 
+def test_max_hp_level_three_fighter_average():
+    """Normal: макс. кость на 1 ур., среднее на 2+."""
+    stats = {"constitution": 14}
+    hp = max_hp_for_level("fighter", stats, 3, "normal")
+    assert hp == 28
+
+
 def test_apply_experience_levels_up_and_caps_hp():
     char = Character(
         name="Hero",
@@ -32,11 +43,39 @@ def test_apply_experience_levels_up_and_caps_hp():
         current_hp=12,
         max_hp=12,
         experience=0,
+        difficulty="normal",
     )
     updated = apply_experience(char, 900)
     assert updated.level == 3
     assert updated.experience == 900
-    assert updated.max_hp > char.max_hp
+    assert updated.max_hp == 28
+    assert updated.current_hp == 28
+
+
+def test_apply_experience_hardcore_adds_rolls_not_average(monkeypatch):
+    """HardCore: прирост HP за каждый новый уровень — бросок кости."""
+    rolls = iter([8, 3])
+
+    def fake_roll(count: int, sides: int, modifier: int = 0) -> int:
+        return next(rolls) + modifier
+
+    monkeypatch.setattr("core.progression.roll", fake_roll)
+
+    char = Character(
+        name="Hero",
+        race="human",
+        class_name="fighter",
+        level=1,
+        stats={"constitution": 14},
+        current_hp=7,
+        max_hp=7,
+        experience=0,
+        difficulty="hardcore",
+    )
+    updated = apply_experience(char, 900)
+    assert updated.level == 3
+    assert updated.max_hp == 22
+    assert updated.current_hp == 22
 
 
 def test_apply_experience_does_not_exceed_level_ten():


### PR DESCRIPTION
Normal/Easy use max die on level 1 and average on level-up; HardCore rolls hit die each level and apply_experience increments max_hp instead of recalculating.