### PR TITLE
chore: add local pre-commit hook for check and test

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,7 +11,7 @@ if [[ -z "$STAGED" ]]; then
 fi
 
 # Только docs/правила — без прогона тестов.
-if ! echo "$STAGED" | grep -qvE '^(docs/|\.cursor/|AGENTS\.md|README\.md|\.github/|\.vscode/)'; then
+if ! echo "$STAGED" | grep -qvE '^(docs/|\.cursor/|\.githooks/|AGENTS\.md|README\.md|\.github/|\.vscode/)'; then
   exit 0
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Локальный pre-commit: make check + make test (не CI).
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+STAGED="$(git diff --cached --name-only --diff-filter=ACM)"
+if [[ -z "$STAGED" ]]; then
+  exit 0
+fi
+
+# Только docs/правила — без прогона тестов.
+if ! echo "$STAGED" | grep -qvE '^(docs/|\.cursor/|AGENTS\.md|README\.md|\.github/|\.vscode/)'; then
+  exit 0
+fi
+
+if [[ ! -x .venv/bin/python ]]; then
+  echo "pre-commit: нет .venv. Запустите: make install" >&2
+  exit 1
+fi
+
+echo "pre-commit: make check..."
+make check
+
+echo "pre-commit: make test..."
+make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help venv-recreate venv install reinstall clean lint format format-check typecheck check test
+.PHONY: help venv-recreate venv install install-hooks reinstall clean lint format format-check typecheck check test
 
 VENV      := .venv
 PYTHON    := python3.12
@@ -19,6 +19,12 @@ venv-recreate:
 .PHONY: install
 install: venv
 	$(PIP) install -e ".[dev]"
+	$(MAKE) install-hooks
+
+.PHONY: install-hooks
+install-hooks:
+	chmod +x .githooks/pre-commit
+	git config core.hooksPath .githooks
 
 .PHONY: reinstall
 reinstall:
@@ -26,6 +32,7 @@ reinstall:
 	rm -rf $(VENV)
 	$(PYTHON) -m venv $(VENV)
 	$(PIP) install -e ".[dev]"
+	$(MAKE) install-hooks
 
 .PHONY: clean
 clean:
@@ -67,7 +74,8 @@ help:
 	@echo "  make help            — показать эту справку"
 	@echo "  make venv            — создать виртуальное окружение (если нет)"
 	@echo "  make venv-recreate   — пересоздать виртуальное окружение"
-	@echo "  make install         — установить/обновить зависимости"
+	@echo "  make install         — зависимости + git pre-commit (check + test)"
+	@echo "  make install-hooks   — подключить .githooks/pre-commit"
 	@echo "  make reinstall       — переустановить все зависимости (с удалением)"
 	@echo "  make clean           — очистить кеш и временные файлы"
 	@echo "  make check           — полная проверка: ruff + black --check + mypy"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -135,7 +135,7 @@ make check   # lint + black --check + mypy
 make install-hooks   # или make install — подключает .githooks/pre-commit
 ```
 
-Коммиты только в `docs/`, `.cursor/`, `AGENTS.md`, `.github/`, `.vscode/` — без прогона. Обход: `git commit --no-verify` (только если осознанно).
+Коммиты только в `docs/`, `.cursor/`, `.githooks/`, `AGENTS.md`, `.github/`, `.vscode/` — без прогона. Обход: `git commit --no-verify` (только если осознанно).
 
 ## Тестирование
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -127,6 +127,16 @@ dnd_mud/
 make check   # lint + black --check + mypy
 ```
 
+### Pre-commit (локально)
+
+Перед коммитом с изменениями кода или данных хук запускает `make check` и `make test` (не GitHub Actions).
+
+```bash
+make install-hooks   # или make install — подключает .githooks/pre-commit
+```
+
+Коммиты только в `docs/`, `.cursor/`, `AGENTS.md`, `.github/`, `.vscode/` — без прогона. Обход: `git commit --no-verify` (только если осознанно).
+
 ## Тестирование
 
 Проект использует `pytest`. Тесты находятся в `tests/`.


### PR DESCRIPTION
## Summary
- Add `.githooks/pre-commit` to run `make check` and `make test` before commits that touch code or data
- Add `make install-hooks`; wire it from `make install` and `make reinstall` via `core.hooksPath`
- Document local pre-commit setup in `docs/DEVELOPMENT.md`

## Test plan
- [x] `make install-hooks` sets `core.hooksPath` to `.githooks`
- [x] Pre-commit hook runs `make check` and `make test` on code/data commits (116 passed)
- [x] Docs-only commits skip the hook

Made with [Cursor](https://cursor.com)