### PR TITLE
fix: legacy class key in character save load

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -121,7 +121,7 @@ class Character:
             difficulty = "normal"
         level_raw = int(data.get("level", 1))
         level = clamp_level(level_raw)
-        class_id_raw = data.get("class_id") or ""
+        class_id_raw = data.get("class_id") or data.get("class") or ""
         return cls(
             name=data.get("name", ""),
             race=data.get("race", ""),

--- a/docs/API.md
+++ b/docs/API.md
@@ -53,7 +53,7 @@ class Character:
 
 **Методы:**
 - `to_dict() -> dict[str, Any]` — сериализация для JSON (ключ класса — `class_id`)
-- `from_dict(data: dict[str, Any]) -> Character` — десериализация; в JSON ожидается `class_id`
+- `from_dict(data: dict[str, Any]) -> Character` — десериализация; ключ класса — `class_id` (при загрузке старых сейвов — fallback на `"class"`)
 
 ### Adventure
 
@@ -453,6 +453,8 @@ tool_check_modifier(character, tool_id, ability_mod) -> int
 ```
 
 Имя файла — slug из `core/slug.make_save_slug()`; при коллизии — `hero_2.json`, `hero_3.json` и т.д.
+
+> **Legacy:** сейвы до переименования поля могли содержать `"class"` вместо `"class_id"`; `from_dict()` читает оба ключа, `to_dict()` пишет только `class_id`.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+- `Character.from_dict()` — fallback на legacy-ключ `"class"` при загрузке старых сейвов (запись — только `class_id`)
+
 ### Changed
 - Рефакторинг техдолга: `core/hp_bonuses.py` (разрыв цикла races↔feats); `class_name` → `class_id` (JSON-сейвы только `class_id`)
 - Декомпозиция: `ui/menus/_display/` (пакет), `core/feats_loader.py` + `feats_grants.py`, `ui/menus/_creation_steps.py` + `_selectors.py`
 - `ui/menus/_deps.py` — re-export из расширенного `core/character.py` (seam для тестов сохранён)
-- Удалены legacy JSON-ключи `class`/`class_name` и re-export в `character_flow.py`
+- Удалены legacy re-export в `character_flow.py`; запись JSON — только `class_id` (чтение старых `"class"` — см. Fixed)
 - Документация синхронизирована: `ARCHITECTURE`, `API`, `DEVELOPMENT`, scenario runner
 
 ### Added

--- a/docs/rules/01-character-creation.md
+++ b/docs/rules/01-character-creation.md
@@ -82,7 +82,7 @@
 
 ### Сохранение персонажа
 
-Путь: `saves/characters/{save_slug}.json`. Поля модели `Character`: `name`, `race`, `class_id`, `level`, `stats`, `current_hp`, `max_hp`, `experience`, `difficulty`, `subrace`, `subclass_id` (JSON: `"subclass"`), `languages`, `background_id` (JSON: `"background"`), …
+Путь: `saves/characters/{save_slug}.json`. Поля модели `Character`: `name`, `race`, `class_id` (JSON; legacy `"class"` читается при загрузке), `level`, `stats`, `current_hp`, `max_hp`, `experience`, `difficulty`, `subrace`, `subclass_id` (JSON: `"subclass"`), `languages`, `background_id` (JSON: `"background"`), …
 
 ### Константы генерации (`core/stats.py`)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,12 +22,17 @@ def test_character_round_trip_with_subrace():
     assert restored.save_slug == "test"
 
 
-def test_character_from_dict_requires_class_id():
-    """from_dict читает только ключ class_id."""
-    character = Character.from_dict(
+def test_character_from_dict_reads_class_id():
+    """from_dict читает class_id; legacy-ключ class — fallback."""
+    from_class_id = Character.from_dict(
         {"name": "X", "race": "human", "class_id": "wizard"}
     )
-    assert character.class_id == "wizard"
+    from_legacy = Character.from_dict(
+        {"name": "Y", "race": "elf", "class": "rogue"}
+    )
+
+    assert from_class_id.class_id == "wizard"
+    assert from_legacy.class_id == "rogue"
 
 
 def test_character_from_dict_defaults():


### PR DESCRIPTION
## Summary
- `Character.from_dict()` falls back to legacy JSON key `"class"` when `"class_id"` is missing, so pre-rename save files keep their class after the `class_name` → `class_id` refactor.
- Test covers both `class_id` and legacy `class` keys.
- Docs updated: `API.md`, `CHANGELOG.md`, `rules/01-character-creation.md`.

## Test plan
- [x] `make test` (261 passed; pre-commit on fix commit)
- [x] `test_character_from_dict_reads_class_id` — new and legacy keys
- [x] Bugbot review vs `dev` — no blockers


Made with [Cursor](https://cursor.com)