### PR TITLE
feat: align database catalogs with PHB rules reference

### DIFF
--- a/database/backgrounds/backgrounds.yaml
+++ b/database/backgrounds/backgrounds.yaml
@@ -40,7 +40,7 @@ backgrounds:
     - type: equipment_item
       items:
       - { kind: equipment, id: emblem, qty: 1 }
-      - { kind: equipment, id: book, qty: 1 }
+      - { kind: equipment, id: prayer_book, qty: 1 }
       - { kind: equipment, id: incense, qty: 5 }
       - { kind: equipment, id: vestments, qty: 1 }
       - { kind: equipment, id: common_clothes, qty: 1 }
@@ -69,6 +69,8 @@ backgrounds:
       description:
         ru: Вторая личность с документами и знакомствами; подделка официальных бумаг.
         en: A second identity with documents and contacts; forge official papers.
+    inventory_tool_pools:
+      - gaming_sets
     grants:
     - type: skill_proficiency
       skills:
@@ -298,7 +300,7 @@ backgrounds:
     - type: equipment_item
       items:
       - { kind: equipment, id: map_case, qty: 1 }
-      - { kind: equipment, id: bedroll, qty: 1 }
+      - { kind: equipment, id: blanket, qty: 1 }
       - { kind: equipment, id: common_clothes, qty: 1 }
       - { kind: tool, id: herbalism_kit, qty: 1 }
   noble:
@@ -343,7 +345,7 @@ backgrounds:
       items:
       - { kind: equipment, id: fine_clothes, qty: 1 }
       - { kind: equipment, id: signet_ring, qty: 1 }
-      - { kind: equipment, id: letter, qty: 1 }
+      - { kind: equipment, id: pedigree_scroll, qty: 1 }
   outlander:
     name:
       ru: Чужеземец
@@ -434,7 +436,7 @@ backgrounds:
       items:
       - { kind: equipment, id: ink, qty: 1 }
       - { kind: equipment, id: quill, qty: 1 }
-      - { kind: equipment, id: paper, qty: 1 }
+      - { kind: equipment, id: parchment, qty: 1 }
       - { kind: weapon, id: dagger, qty: 1 }
       - { kind: equipment, id: letter, qty: 1 }
       - { kind: equipment, id: common_clothes, qty: 1 }
@@ -571,6 +573,7 @@ backgrounds:
     - type: equipment_item
       items:
       - { kind: weapon, id: dagger, qty: 1 }
-      - { kind: equipment, id: map_case, qty: 1 }
+      - { kind: equipment, id: city_map, qty: 1 }
+      - { kind: equipment, id: pet_mouse, qty: 1 }
       - { kind: equipment, id: trinket, qty: 1 }
       - { kind: equipment, id: common_clothes, qty: 1 }

--- a/database/classes/classes.yaml
+++ b/database/classes/classes.yaml
@@ -237,26 +237,68 @@ classes:
           feature_type: passive
           requires_action: false
         - id: second_wind
-          name: Восстановление
-          description: Короткий отдых восстанавливает часть здоровья
+          name: Второе дыхание
+          description: Бонусным действием восстановить 1к10 + уровень воина хитов; 1 раз за короткий отдых
           feature_type: active
           uses_per_rest: 1
-          requires_action: true
+          requires_action: false
           bonus_action: true
+      2:
+        grants:
+        - id: action_surge
+          name: Всплеск действий
+          description: Дополнительное действие в свой ход; 1 раз за короткий отдых (2 раза с 17 уровня)
+          feature_type: active
+          uses_per_rest: 1
+          requires_action: false
       5:
         grants:
-        - id: improved_second_wind
-          name: Улучшенное восстановление
-          description: Увеличенное количество здоровья при восстановлении
+        - id: extra_attack
+          name: Дополнительная атака
+          description: Две атаки при действии Атака
           feature_type: passive
+          requires_action: false
+      9:
+        grants:
+        - id: indomitable
+          name: Упорный
+          description: Переброс проваленного спасброска; 1 раз за долгий отдых (2 на 13 ур., 3 на 17 ур.)
+          feature_type: active
+          uses_per_rest: 1
           requires_action: false
       11:
         grants:
-        - id: extra_attack
-          name: Атака дополнительным действием
-          description: Возможность атаковать как дополнительное действие
-          feature_type: active
-          requires_action: true
+        - id: extra_attack_2
+          name: Дополнительная атака
+          description: Три атаки при действии Атака
+          feature_type: passive
+          requires_action: false
+      13:
+        grants:
+        - id: indomitable_2
+          name: Упорный (13 ур.)
+          description: Два использования Упорного за долгий отдых
+          feature_type: passive
+          requires_action: false
+      17:
+        grants:
+        - id: action_surge_2
+          name: Всплеск действий (17 ур.)
+          description: Всплеск действий можно использовать дважда за короткий отдых
+          feature_type: passive
+          requires_action: false
+        - id: indomitable_3
+          name: Упорный (17 ур.)
+          description: Три использования Упорного за долгий отдых
+          feature_type: passive
+          requires_action: false
+      20:
+        grants:
+        - id: extra_attack_3
+          name: Дополнительная атака
+          description: Четыре атаки при действии Атака
+          feature_type: passive
+          requires_action: false
       4:
         grants:
         - id: ability_score_improvement
@@ -552,25 +594,55 @@ classes:
       2:
         grants:
         - id: cunning_action
-          name: Коварная атака
-          description: Использование бонусного действия для атаки или уклонения
+          name: Хитрое действие
+          description: Бонусным действием — Рывок, Отход или Засада
           feature_type: active
           requires_action: false
           bonus_action: true
-      3:
-        grants:
-        - id: improved_sneak_attack
-          name: Улучшенная скрытая атака
-          description: Увеличение урона скрытой атаки
-          feature_type: passive
-          requires_action: false
-      9:
+      5:
         grants:
         - id: uncanny_dodge
-          name: Улучшенная коварная атака
-          description: Дополнительная атака при коварной атаке
+          name: Невероятное уклонение
+          description: Реакцией при видимой атаке — половина урона
           feature_type: active
           reaction: true
+          requires_action: false
+      7:
+        grants:
+        - id: evasion
+          name: Уклонение
+          description: Успех на спасбросках Ловкости при половинном уроне
+          feature_type: passive
+          requires_action: false
+      11:
+        grants:
+        - id: reliable_talent
+          name: Надёжный талант
+          description: '10+ на проверках с компетентностью'
+          feature_type: passive
+          requires_action: false
+      14:
+        grants:
+        - id: blindsense
+          name: Слепое зрение
+          description: Слышите скрытых существ в 10 фт.
+          feature_type: passive
+          requires_action: false
+      18:
+        grants:
+        - id: elusive
+          name: Неуловимость
+          description: Атаки по вам без преимущества не получают преимущество
+          feature_type: passive
+          requires_action: false
+      20:
+        grants:
+        - id: stroke_of_luck
+          name: Удачный случай
+          description: Переброс проваленной проверки, атаки или спасброска; 1/короткий или долгий отдых
+          feature_type: active
+          uses_per_rest: 1
+          requires_action: false
       4:
         grants:
         - id: ability_score_improvement
@@ -871,14 +943,12 @@ classes:
             характеристика — Мудрость
           feature_type: spell
           requires_action: true
-        - id: ritual_casting
-          name: Заклинание ритуала
-          description: Возможность колдовать заклинания как ритуалы
-          feature_type: passive
-          requires_action: false
-        - id: spell_recovery
-          name: Восстановление заклинаний
-          description: Восстановление части заклинаний после короткого отдыха
+      2:
+        grants:
+        - id: channel_divinity
+          name: Божественный канал
+          description: Изгнание нежити и эффект божественного домена; 1 раз за короткий или долгий отдых (2 на 6 ур., 3 на
+            18 ур.)
           feature_type: active
           uses_per_rest: 1
           requires_action: true
@@ -886,9 +956,9 @@ classes:
         grants:
         - id: destroy_undead
           name: Уничтожение нежити
-          description: Способность наносить дополнительный урон нежити
-          feature_type: active
-          requires_action: true
+          description: Божественный канал «Изгнание нежити» уничтожает нежить ниже порога КО по уровню жреца
+          feature_type: passive
+          requires_action: false
       10:
         grants:
         - id: divine_intervention
@@ -937,6 +1007,14 @@ classes:
             возьмите черту.'
           feature_type: passive
           requires_action: false
+      20:
+        grants:
+        - id: supreme_divine_intervention
+          name: Высшее божественное вмешательство
+          description: Божественное вмешательство автоматически успешно; 1 раз за 7 дней
+          feature_type: active
+          uses_per_rest: 1
+          requires_action: true
   bard:
     name:
       ru: Бард
@@ -1187,6 +1265,27 @@ classes:
           description: Два заклинания любого класса (уровень доступных ячеек или заговор); считаются заклинаниями барда
           feature_type: spell
           requires_action: true
+      14:
+        grants:
+        - id: magical_secrets_14
+          name: Тайны магии (14 ур.)
+          description: Ещё два заклинания любого класса
+          feature_type: spell
+          requires_action: true
+      18:
+        grants:
+        - id: magical_secrets_18
+          name: Тайны магии (18 ур.)
+          description: Ещё два заклинания любого класса
+          feature_type: spell
+          requires_action: true
+      20:
+        grants:
+        - id: superior_inspiration
+          name: Превосходное вдохновение
+          description: При броске инициативы, если нет использований вдохновения барда — восстановить одно
+          feature_type: passive
+          requires_action: false
       4:
         grants:
         - id: ability_score_improvement

--- a/database/classes/classes.yaml
+++ b/database/classes/classes.yaml
@@ -1013,7 +1013,6 @@ classes:
           name: Высшее божественное вмешательство
           description: Божественное вмешательство автоматически успешно; 1 раз за 7 дней
           feature_type: active
-          uses_per_rest: 1
           requires_action: true
   bard:
     name:

--- a/database/core/abilities.yaml
+++ b/database/core/abilities.yaml
@@ -6,7 +6,7 @@ abilities:
     name: "Сила"
     description: "Физическая мощь, атлетизм, грузоподъёмность"
     skills:
-      athletics: "Атлетика — плавание, climbing, прыжки"
+      athletics: "Атлетика — плавание, лазание, прыжки"
 
   dexterity:
     name: "Ловкость"

--- a/database/core/constants.yaml
+++ b/database/core/constants.yaml
@@ -85,7 +85,7 @@ constants:
 
   # Типы языков
   language_types:
-    standard: "Стандартные языки"
+    common: "Стандартные языки"
     exotic: "Экзотические языки"
     secret: "Секретные языки"
     elemental: "Элементальные языки"

--- a/database/equipment/equipment.yaml
+++ b/database/equipment/equipment.yaml
@@ -236,6 +236,42 @@ equipment:
     cost: { value: 25, currency: "gold" }
     weight: 5
 
+  prayer_book:
+    name: "Молитвенник"
+    category: "tools_and_kits"
+    cost: { value: 25, currency: "gold" }
+    weight: 5
+
+  blanket:
+    name: "Одеяло"
+    category: "tools_and_kits"
+    cost: { value: 5, currency: "silver" }
+    weight: 3
+
+  parchment:
+    name: "Пергамент (один лист)"
+    category: "tools_and_kits"
+    cost: { value: 1, currency: "silver" }
+    weight: null
+
+  pedigree_scroll:
+    name: "Свиток родословной"
+    category: "tools_and_kits"
+    cost: { value: 1, currency: "gold" }
+    weight: null
+
+  city_map:
+    name: "Карта города"
+    category: "tools_and_kits"
+    cost: { value: 1, currency: "gold" }
+    weight: null
+
+  pet_mouse:
+    name: "Ручная крыса"
+    category: "tools_and_kits"
+    cost: { value: 0, currency: "gold" }
+    weight: null
+
   spellbook:
     name: "Книга заклинаний"
     category: "tools_and_kits"
@@ -412,13 +448,13 @@ equipment:
   hooded_lantern:
     name: "Фонарь закрытый"
     category: "tools_and_kits"
-    cost: { value: 10, currency: "gold" }
+    cost: { value: 5, currency: "gold" }
     weight: 2
 
   bullseye_lantern:
     name: "Фонарь направленный"
     category: "tools_and_kits"
-    cost: { value: 5, currency: "gold" }
+    cost: { value: 10, currency: "gold" }
     weight: 2
 
   chain:
@@ -452,8 +488,8 @@ equipment:
   piton:
     name: "Шлямбур"
     category: "tools_and_kits"
-    cost: { value: 1, currency: "gold" }
-    weight: 5
+    cost: { value: 5, currency: "copper" }
+    weight: 0.25
 
   backpack:
     name: "Рюкзак"
@@ -585,7 +621,7 @@ equipment:
   vestments:
     name: "Облачение"
     category: "adventuring_gear"
-    cost: { value: 0, currency: "gold" }
+    cost: { value: 1, currency: "gold" }
     weight: 4
 
   incense:

--- a/database/equipment/weapon.yaml
+++ b/database/equipment/weapon.yaml
@@ -197,11 +197,13 @@ weapons:
   pike:
     name: "Длинное копьё"
     category: "martial_melee"
-    cost: { value: 10, currency: "gold" }
-    damage: { dice: "1d12", type: "piercing" }
-    weight: 6
+    cost: { value: 5, currency: "gold" }
+    damage: { dice: "1d10", type: "piercing" }
+    weight: 18
     properties:
       reach: true
+      two_handed: true
+      heavy: true
       special: true
 
   longsword:
@@ -254,13 +256,12 @@ weapons:
   lance:
     name: "Пика"
     category: "martial_melee"
-    cost: { value: 5, currency: "gold" }
-    damage: { dice: "1d10", type: "piercing" }
-    weight: 18
+    cost: { value: 10, currency: "gold" }
+    damage: { dice: "1d12", type: "piercing" }
+    weight: 6
     properties:
-      two_handed: true
       reach: true
-      heavy: true
+      special: true
 
   rapier:
     name: "Рапира"

--- a/database/progression/feats.yaml
+++ b/database/progression/feats.yaml
@@ -491,7 +491,7 @@ feats:
     - type: alert
       cannot_be_surprised_while_conscious: true
       hidden_attackers_no_advantage: true
-      name: Бдительность
+      name: Защита от засады
   martial_adept:
     name: Воинский адепт
     description: Два приёма воина и одна кость превосходства (к6).

--- a/database/progression/feats.yaml
+++ b/database/progression/feats.yaml
@@ -141,6 +141,8 @@ feats:
     - type: charger
       dash_bonus_action: true
       charge_damage_bonus: 5
+      shove_bonus_action: true
+      shove_distance: 10
       name: Налёт
   crossbow_expert:
     name: Эксперт в арбалетах
@@ -160,6 +162,7 @@ feats:
       weapon_type: crossbow
       ignore_loading: true
       bonus_action_attack: true
+      ranged_no_disadvantage_in_melee: true
       name: Мастерство арбалетов
   defensive_duelist:
     name: Оборонительный дуэлянт
@@ -192,6 +195,8 @@ feats:
     grants:
     - type: dual_wielder
       ac_bonus: 1
+      non_light_dual_wield: true
+      draw_stow_two_weapons: true
       name: Два оружия
   dungeon_delver:
     name: Исследователь подземелий
@@ -210,8 +215,14 @@ feats:
       '
     grants:
     - type: trap_mastery
+      advantage_skills:
+      - perception
+      - investigation
+      context: secret_doors
       advantage_saves: traps
-      counter_attack_damage: 1d6
+      resistance:
+      - trap_damage
+      search_traps_normal_speed: true
       name: Мастерство ловушек
   durable:
     name: Стойкий
@@ -294,7 +305,7 @@ feats:
     grants:
     - type: healing
       healer_kit_bonus: true
-      stabilize_no_check: true
+      stabilize_restores_1_hp: true
       heal_dice: 1d6
       heal_flat: 4
       heal_plus_target_max_hit_dice: true
@@ -477,6 +488,10 @@ feats:
     - type: initiative_bonus
       bonus: 5
       name: Бдительность
+    - type: alert
+      cannot_be_surprised_while_conscious: true
+      hidden_attackers_no_advantage: true
+      name: Бдительность
   martial_adept:
     name: Воинский адепт
     description: Два приёма воина и одна кость превосходства (к6).
@@ -538,6 +553,9 @@ feats:
       - investigation
       bonus: 5
       name: Внимательность
+    - type: lip_reading
+      requires_known_language: true
+      name: Чтение по губам
   inspiring_leader:
     name: Воодушевляющий лидер
     description: 10 минут — временные хиты (уровень + модификатор Харизмы) до 6 существ в 30 фт.
@@ -590,6 +608,7 @@ feats:
       unarmed_die: 4
       weapon_proficiency:
       - improvised
+      bonus_action_grapple_on_hit: true
       name: Мордобой
   great_weapon_master:
     name: Мастер большого оружия
@@ -805,6 +824,8 @@ feats:
       count: 3
       choice: true
       name: Языки
+    - type: cipher_writing
+      name: Шифрованные письма
   skulker:
     name: Проныра
     description: Скрытность при слабом укрытии; выстрел не выдаёт позицию; тусклый свет не мешает Внимательности.

--- a/database/races/races.yaml
+++ b/database/races/races.yaml
@@ -117,9 +117,6 @@ races:
           - shortbow
           type: weapon_proficiency
           name: Эльфийская боевая подготовка
-        - type: speed_bonus
-          amount: 35
-          name: Быстрота
         - skill: stealth
           terrain: forest
           type: advantage
@@ -132,6 +129,9 @@ races:
         ability_bonuses:
           charisma: 1
         grants:
+        - range: 120
+          type: darkvision
+          name: Тёмное зрение
         - spells:
           - name: dancing_lights
             level: 0
@@ -170,6 +170,9 @@ races:
     - save: charisma
       effect: charm
       type: advantage
+      name: Наследие фей
+    - effect: magical_sleep
+      type: immunity
       name: Наследие фей
     - duration: 4
       effect: full_rest
@@ -275,9 +278,22 @@ races:
           strength: 2
           constitution: 1
         grants:
+        - range: 60
+          type: darkvision
+          name: Тёмное зрение
+        - skills:
+          - intimidation
+          type: skill_proficiency
+          name: Устрашающий вид
         - type: persistent_endurance
           trigger: damage_reduces_to_zero
           effect: remain_at_1_hp
+          name: Неукротимость
+          description: При снижении до 0 хитов, но не убит — остаться с 1 хитом (1/долгий отдых)
         - type: damage_bonus
           trigger: critical_hit
-          effect: reroll_one_damage_die
+          weapon_types:
+          - melee
+          effect: extra_weapon_damage_die
+          name: Свирепые атаки
+          description: При критическом попадании рукопашной атакой — один дополнительный куб урона оружия

--- a/database/races/races.yaml
+++ b/database/races/races.yaml
@@ -81,6 +81,9 @@ races:
         ability_bonuses:
           intelligence: 1
         grants:
+        - range: 60
+          type: darkvision
+          name: Тёмное зрение
         - weapons:
           - longsword
           - rapier
@@ -109,6 +112,9 @@ races:
           wisdom: 1
         speed: 35
         grants:
+        - range: 60
+          type: darkvision
+          name: Тёмное зрение
         - weapons:
           - longsword
           - rapier
@@ -164,9 +170,6 @@ races:
       - perception
       type: skill_proficiency
       name: Обострённые чувства
-    - range: 60
-      type: darkvision
-      name: Тёмное зрение
     - save: charisma
       effect: charm
       type: advantage

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- **Каталоги `database/` ↔ PHB:** расы (`half_orc`, дроу 120 фт., наследие фей), прогрессия 4 классов (fighter/rogue/cleric/bard), grants 9 черт, предыстории (equipment_item), снаряжение (lance/pike, фонари, piton, vestments); `language_types.common` в `constants.yaml`
 - **Документация `docs/`:** индекс [`docs/README.md`](README.md); ссылки на `rules/chapters/`; глоссарии → `rules/reference/glossaries/`
 - **Справочник без лора:** карточки рас, предысторий и классов; главы `00`–`03`, `04-backgrounds` — только механика
 - **Справочник для агентов (layout `agent-v2`):** единый [`docs/rules/_index/lookup.yaml`](rules/_index/lookup.yaml) (`by_id`, `by_alias`, `summaries`); поле `quick` в frontmatter; нормализация карточек feats и секций `higher-levels` заклинаний через `scripts/build_rules_index.py`
@@ -25,6 +26,7 @@
 - Git workflow: **все** ветки `merged/*` — только локальный архив; запрещены push/upstream/PR на `origin`; legacy `origin/merged/*` удалять (`dnd-mud-workflow.mdc`, `01-operations.mdc`, `user-protocols.mdc`)
 
 ### Added
+- `tests/test_phb_catalog_alignment.py`, `tests/fixtures/phb_equipment.yaml` — регрессии выравнивания каталогов с PHB
 - **Спасброски класса:** `saving_throws` в `classes.yaml`, поле `save_proficiencies` на `Character`, `core/checks.py` (`saving_throw_modifier`, `saving_throw`)
 - **Стартовое снаряжение:** `starting_equipment` в YAML, шаг `equipment` при создании, `core/starting_equipment.py`, `core/inventory.py` (инвентарь, экипировка, `compute_ac`)
 - PHB-наборы (`explorers_pack`, `dungeoneers_pack`, …) в `database/equipment/equipment.yaml`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Changed
-- **Каталоги `database/` ↔ PHB:** расы (`half_orc`, дроу 120 фт., наследие фей), прогрессия 4 классов (fighter/rogue/cleric/bard), grants 9 черт, предыстории (equipment_item), снаряжение (lance/pike, фонари, piton, vestments); `language_types.common` в `constants.yaml`
+- **Каталоги `database/` ↔ PHB:** расы (`half_orc`, наследие фей; тёмное зрение эльфов в подрасах — дроу 120 фт.), прогрессия 4 классов (fighter/rogue/cleric/bard), grants 9 черт, предыстории (`equipment_item`), снаряжение (lance/pike, фонари, piton, vestments); `language_types.common` в `constants.yaml`
 - **Документация `docs/`:** индекс [`docs/README.md`](README.md); ссылки на `rules/chapters/`; глоссарии → `rules/reference/glossaries/`
 - **Справочник без лора:** карточки рас, предысторий и классов; главы `00`–`03`, `04-backgrounds` — только механика
 - **Справочник для агентов (layout `agent-v2`):** единый [`docs/rules/_index/lookup.yaml`](rules/_index/lookup.yaml) (`by_id`, `by_alias`, `summaries`); поле `quick` в frontmatter; нормализация карточек feats и секций `higher-levels` заклинаний через `scripts/build_rules_index.py`
@@ -18,6 +18,7 @@
 - Стартовое снаряжение предысторий: PHB-наборы (солдат — кости/карты, преступник — тёмная одежда), `inventory_tool_pools`
 - Меню снаряжения класса: владение конкретным оружием (warhammer у дварфа), предупреждение `(Сил N)` для тяжёлых доспехов
 - Карточка персонажа: слоты экипировки всегда видны, PHB-подсказки доспеха/оружия, versatile/ammo/range
+- PHB catalog review: дроу — одно тёмное зрение 120 фт. (базовый grant эльфа перенесён в `high_elf`/`wood_elf`); `supreme_divine_intervention` без неверного `uses_per_rest`; пример acolyte в `DATA_SCHEMA.md` — `prayer_book`
 
 ### Changed
 - MUD_PRD §3.2.1: перекрёстная ссылка на правила расчёта HP по режимам сложности
@@ -26,7 +27,7 @@
 - Git workflow: **все** ветки `merged/*` — только локальный архив; запрещены push/upstream/PR на `origin`; legacy `origin/merged/*` удалять (`dnd-mud-workflow.mdc`, `01-operations.mdc`, `user-protocols.mdc`)
 
 ### Added
-- `tests/test_phb_catalog_alignment.py`, `tests/fixtures/phb_equipment.yaml` — регрессии выравнивания каталогов с PHB
+- `tests/test_phb_catalog_alignment.py`, `tests/fixtures/phb_equipment.yaml` — регрессии выравнивания каталогов с PHB (расы, классы, feats, снаряжение)
 - **Спасброски класса:** `saving_throws` в `classes.yaml`, поле `save_proficiencies` на `Character`, `core/checks.py` (`saving_throw_modifier`, `saving_throw`)
 - **Стартовое снаряжение:** `starting_equipment` в YAML, шаг `equipment` при создании, `core/starting_equipment.py`, `core/inventory.py` (инвентарь, экипировка, `compute_ac`)
 - PHB-наборы (`explorers_pack`, `dungeoneers_pack`, …) в `database/equipment/equipment.yaml`

--- a/docs/DATA_SCHEMA.md
+++ b/docs/DATA_SCHEMA.md
@@ -106,7 +106,7 @@ backgrounds:
       - type: equipment_item
         items:
           - { kind: equipment, id: emblem, qty: 1 }
-          - { kind: equipment, id: book, qty: 1 }
+          - { kind: equipment, id: prayer_book, qty: 1 }
     inventory_tool_pools:   # опционально: picks инструментов → инвентарь PHB
       - musical_instruments
     feature:   # flavor до game engine

--- a/tests/fixtures/phb_equipment.yaml
+++ b/tests/fixtures/phb_equipment.yaml
@@ -1,0 +1,19 @@
+# Эталон PHB 2014 (гл. 5) для сверки database/equipment/*.yaml
+weapons:
+  lance:
+    cost: { value: 10, currency: gold }
+    damage: { dice: "1d12", type: piercing }
+    weight: 6
+  pike:
+    cost: { value: 5, currency: gold }
+    damage: { dice: "1d10", type: piercing }
+    weight: 18
+gear:
+  hooded_lantern:
+    cost: { value: 5, currency: gold }
+  bullseye_lantern:
+    cost: { value: 10, currency: gold }
+  piton:
+    cost: { value: 5, currency: copper }
+  vestments:
+    cost: { value: 1, currency: gold }

--- a/tests/test_background_equipment.py
+++ b/tests/test_background_equipment.py
@@ -61,7 +61,7 @@ def test_get_background_equipment_items_acolyte_phb_gear() -> None:
     items = get_background_equipment_items("acolyte")
     ids = {(i["kind"], i["id"]) for i in items}
     assert ("equipment", "emblem") in ids
-    assert ("equipment", "book") in ids
+    assert ("equipment", "prayer_book") in ids
     assert ("equipment", "incense") in ids
     assert ("equipment", "vestments") in ids
     assert ("equipment", "common_clothes") in ids

--- a/tests/test_phb_catalog_alignment.py
+++ b/tests/test_phb_catalog_alignment.py
@@ -1,0 +1,144 @@
+"""Сверка каталогов database/ с каноном docs/rules (PHB partial)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from core.classes import get_class_dict
+from core.races import collect_race_grants, get_race_bonuses
+
+pytestmark = pytest.mark.usefixtures("catalog_caches_cleared")
+
+ROOT = Path(__file__).resolve().parent.parent
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "phb_equipment.yaml"
+
+
+def _load_yaml(path: Path, key: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    assert isinstance(data, dict)
+    section = data.get(key, {})
+    assert isinstance(section, dict)
+    return section
+
+
+ALL_STATS = [
+    "strength",
+    "dexterity",
+    "constitution",
+    "intelligence",
+    "wisdom",
+    "charisma",
+]
+
+
+@pytest.mark.parametrize(
+    ("race_id", "subrace_id", "bonuses"),
+    [
+        ("human", "standard", dict.fromkeys(ALL_STATS, 1)),
+        ("dwarf", "mountain_dwarf", {"constitution": 2, "strength": 2}),
+        ("half_orc", "half_orc", {"strength": 2, "constitution": 1}),
+    ],
+)
+def test_race_ability_bonuses_match_phb(
+    race_id: str, subrace_id: str, bonuses: dict[str, int]
+) -> None:
+    """Бонусы характеристик рас соответствуют PHB."""
+    assert get_race_bonuses(race_id, subrace_id) == bonuses
+
+
+@pytest.mark.parametrize(
+    ("race_id", "subrace_id", "grant_type"),
+    [
+        ("half_orc", "half_orc", "darkvision"),
+        ("half_orc", "half_orc", "skill_proficiency"),
+        ("elf", "dark_elf_drow", "darkvision"),
+        ("elf", None, "immunity"),
+    ],
+)
+def test_race_grants_include_phb_features(
+    race_id: str, subrace_id: str | None, grant_type: str
+) -> None:
+    """Ключевые расовые особенности присутствуют в grants."""
+    types = {g.get("type") for g in collect_race_grants(race_id, subrace_id)}
+    assert grant_type in types
+
+
+@pytest.mark.parametrize(
+    ("class_id", "level", "feature_id"),
+    [
+        ("fighter", 2, "action_surge"),
+        ("fighter", 5, "extra_attack"),
+        ("rogue", 2, "cunning_action"),
+        ("rogue", 5, "uncanny_dodge"),
+        ("cleric", 2, "channel_divinity"),
+        ("bard", 14, "magical_secrets_14"),
+    ],
+)
+def test_class_progression_feature_ids(
+    class_id: str, level: int, feature_id: str
+) -> None:
+    """Умения класса на уровне соответствуют PHB-карточкам."""
+    info = get_class_dict(class_id)
+    assert info
+    progression = info.get("progression", {})
+    level_data = progression.get(level) or progression.get(str(level), {})
+    if not isinstance(level_data, dict):
+        grants: list[Any] = []
+    else:
+        grants = level_data.get("grants", [])
+    ids = {g.get("id") for g in grants if isinstance(g, dict)}
+    assert feature_id in ids
+
+
+def test_phb_equipment_fixture_matches_catalog() -> None:
+    """Исправленные предметы снаряжения совпадают с эталоном PHB."""
+    expected = yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))
+    assert isinstance(expected, dict)
+
+    weapons = _load_yaml(ROOT / "database/equipment/weapon.yaml", "weapons")
+    gear = _load_yaml(ROOT / "database/equipment/equipment.yaml", "equipment")
+
+    for weapon_id, exp in expected.get("weapons", {}).items():
+        item = weapons[weapon_id]
+        assert item["cost"] == exp["cost"]
+        assert item["damage"] == exp["damage"]
+        assert item["weight"] == exp["weight"]
+
+    for gear_id, exp in expected.get("gear", {}).items():
+        assert gear[gear_id]["cost"] == exp["cost"]
+
+
+@pytest.mark.parametrize(
+    "feat_id",
+    [
+        "dungeon_delver",
+        "healer",
+        "alert",
+        "linguist",
+    ],
+)
+def test_feat_grants_no_removed_phb_fields(feat_id: str) -> None:
+    """Grants черт не содержат устаревших полей после выравнивания с PHB."""
+    feats = _load_yaml(ROOT / "database/progression/feats.yaml", "feats")
+    feat = feats[feat_id]
+    grants = feat.get("grants", [])
+    assert isinstance(grants, list)
+    for grant in grants:
+        assert isinstance(grant, dict)
+        assert "counter_attack_damage" not in grant
+        assert "stabilize_no_check" not in grant
+    if feat_id == "dungeon_delver":
+        trap = next(g for g in grants if g.get("type") == "trap_mastery")
+        assert trap.get("search_traps_normal_speed") is True
+    if feat_id == "healer":
+        heal = next(g for g in grants if g.get("type") == "healing")
+        assert heal.get("stabilize_restores_1_hp") is True
+    if feat_id == "alert":
+        assert any(g.get("type") == "alert" for g in grants)
+    if feat_id == "linguist":
+        assert any(g.get("type") == "cipher_writing" for g in grants)

--- a/tests/test_phb_catalog_alignment.py
+++ b/tests/test_phb_catalog_alignment.py
@@ -69,6 +69,24 @@ def test_race_grants_include_phb_features(
 
 
 @pytest.mark.parametrize(
+    ("subrace_id", "expected_range"),
+    [
+        ("high_elf", 60),
+        ("wood_elf", 60),
+        ("dark_elf_drow", 120),
+    ],
+)
+def test_elf_subrace_darkvision_range(
+    subrace_id: str, expected_range: int
+) -> None:
+    """Тёмное зрение эльфийских подрас — один grant с дальностью PHB."""
+    grants = collect_race_grants("elf", subrace_id)
+    darkvision = [g for g in grants if g.get("type") == "darkvision"]
+    assert len(darkvision) == 1
+    assert darkvision[0].get("range") == expected_range
+
+
+@pytest.mark.parametrize(
     ("class_id", "level", "feature_id"),
     [
         ("fighter", 2, "action_surge"),
@@ -120,6 +138,11 @@ def test_phb_equipment_fixture_matches_catalog() -> None:
         "healer",
         "alert",
         "linguist",
+        "crossbow_expert",
+        "charger",
+        "dual_wielder",
+        "observant",
+        "tavern_brawler",
     ],
 )
 def test_feat_grants_no_removed_phb_fields(feat_id: str) -> None:
@@ -142,3 +165,21 @@ def test_feat_grants_no_removed_phb_fields(feat_id: str) -> None:
         assert any(g.get("type") == "alert" for g in grants)
     if feat_id == "linguist":
         assert any(g.get("type") == "cipher_writing" for g in grants)
+    if feat_id == "crossbow_expert":
+        mastery = next(g for g in grants if g.get("type") == "weapon_mastery")
+        assert mastery.get("ranged_no_disadvantage_in_melee") is True
+    if feat_id == "charger":
+        charge = next(g for g in grants if g.get("type") == "charger")
+        assert charge.get("shove_bonus_action") is True
+        assert charge.get("shove_distance") == 10
+    if feat_id == "dual_wielder":
+        dual = next(g for g in grants if g.get("type") == "dual_wielder")
+        assert dual.get("non_light_dual_wield") is True
+        assert dual.get("draw_stow_two_weapons") is True
+    if feat_id == "observant":
+        assert any(g.get("type") == "lip_reading" for g in grants)
+    if feat_id == "tavern_brawler":
+        brawler = next(
+            g for g in grants if g.get("type") == "unarmed_improvised"
+        )
+        assert brawler.get("bonus_action_grapple_on_hit") is True


### PR DESCRIPTION
## Summary

- Align `database/` catalogs with PHB 2014 (`docs/rules/`): races (`half_orc`, elf subrace darkvision, fey ancestry), class progression for fighter/rogue/cleric/bard, 9 feat grants, background equipment items, and equipment fixes (lance/pike, lanterns, piton, vestments).
- Add `tests/test_phb_catalog_alignment.py` and `tests/fixtures/phb_equipment.yaml` for regression coverage; extend background equipment test for acolyte `prayer_book`.
- Post-review fixes: dedupe drow darkvision (120 ft only), cleric level-20 intervention metadata, alert feat grant labels; sync `DATA_SCHEMA.md` and `CHANGELOG.md`.

## Test plan

- [x] `make verify-scope` (35 tests in diff scope)
- [x] `tests/test_phb_catalog_alignment.py` — races, classes, feats, equipment fixture
- [x] `tests/test_background_equipment.py` — acolyte/charlatan background gear
- [ ] CI full suite on PR


Made with [Cursor](https://cursor.com)