### PR TITLE
chore(tooling): add make branch-cleanup for merged part-branches

### DIFF
--- a/.cursor/rules/dnd-mud-workflow.mdc
+++ b/.cursor/rules/dnd-mud-workflow.mdc
@@ -87,7 +87,7 @@ git fetch origin && git rebase origin/dev
      git merge --no-ff "${PART}" -m "merge(${PART}): into ${TASK}"
      git branch -d "${PART}"    # ОБЯЗАТЕЛЬНО: сразу после успешного merge
    done
-   make branch-cleanup          # резерв: удалить все слитые в dev part-ветки одной командой
+   make branch-cleanup CLEANUP_BASE="${TASK}"   # резерв: удалить все слитые в ${TASK} part-ветки одной командой
    ```
 4. **Финализация** — только на **`feat/<slug>`**: docs-after-task → commit → review → push/PR → `merged/…`.
 
@@ -99,7 +99,7 @@ git log --oneline feat/<slug> | head -20
 git branch --list 'feat/*' 'chore/*' 'refactor/*' 'fix/*'   # незаархивированные part-ветки
 ```
 
-**Чистка part-веток** (после merge всех part в `feat/<slug>`; при финализации — после rename в `merged/*`): `make branch-cleanup` — `git branch -d` всех веток, слитых в `dev`; `merged/*`, `main`, `dev` не трогает. Не оставлять слитые part-ветки без префикса `merged/`.
+**Чистка part-веток** (после merge всех part в `feat/<slug>`; при финализации — после rename в `merged/*`): `make branch-cleanup` — `git branch -d` всех веток, слитых в `CLEANUP_BASE` (по умолчанию `dev`; в контексте §2b, до merge в `dev` — `CLEANUP_BASE=feat/<slug>`); `merged/*`, `main`, `dev` не трогает. Не оставлять слитые part-ветки без префикса `merged/`.
 
 | Критерий | OK | Нарушение (стоп) |
 |----------|-----|------------------|

--- a/.cursor/rules/dnd-mud-workflow.mdc
+++ b/.cursor/rules/dnd-mud-workflow.mdc
@@ -77,15 +77,17 @@ git fetch origin && git rebase origin/dev
    - Реализация **только** scope этого PR.
    - **Commit** (≥1) на part-ветке.
    - **Запрещено** переходить к PR-(N+1), пока PR-N не закоммичен на своей ветке.
-3. **После всех N part-веток** — слить каждую в интеграционную (**до** docs финализации / review / PR):
+3. **После всех N part-веток** — слить каждую в интеграционную (**до** docs финализации / review / PR).
+   **Merge и удаление — атомарная пара:** сразу после успешного `--no-ff` merge part-ветка **удаляется** (`git branch -d`). Слитая part-ветка без префикса `merged/` не остаётся.
    ```bash
    TASK=feat/<slug>
    git fetch origin
    git checkout "${TASK}" && git rebase origin/dev
    for PART in chore/docs-tooling-sync refactor/save-migrations ...; do
      git merge --no-ff "${PART}" -m "merge(${PART}): into ${TASK}"
-     git branch -d "${PART}"    # локально, после успешного merge
+     git branch -d "${PART}"    # ОБЯЗАТЕЛЬНО: сразу после успешного merge
    done
+   make branch-cleanup          # резерв: удалить все слитые в dev part-ветки одной командой
    ```
 4. **Финализация** — только на **`feat/<slug>`**: docs-after-task → commit → review → push/PR → `merged/…`.
 

--- a/.cursor/rules/dnd-mud-workflow.mdc
+++ b/.cursor/rules/dnd-mud-workflow.mdc
@@ -94,8 +94,10 @@ git fetch origin && git rebase origin/dev
 ```bash
 # Ожидаемое N — из таблицы шага 0; part-ветки уже слиты, но reflog/merge commits видны:
 git log --oneline feat/<slug> | head -20
-git branch --list 'feat/*' 'chore/*' 'refactor/*' 'fix/*'
+git branch --list 'feat/*' 'chore/*' 'refactor/*' 'fix/*'   # незаархивированные part-ветки
 ```
+
+**Чистка part-веток** (после merge всех part в `feat/<slug>`; при финализации — после rename в `merged/*`): `make branch-cleanup` — `git branch -d` всех веток, слитых в `dev`; `merged/*`, `main`, `dev` не трогает. Не оставлять слитые part-ветки без префикса `merged/`.
 
 | Критерий | OK | Нарушение (стоп) |
 |----------|-----|------------------|
@@ -103,6 +105,7 @@ git branch --list 'feat/*' 'chore/*' 'refactor/*' 'fix/*'
 | Слияние в `feat/<slug>` | все part слиты `--no-ff` | review/PR с незакрытых part-веток |
 | Текущая ветка для review/PR | `feat/<slug>` | part-ветка, `main`, `dev` |
 | Commits на part-ветках | есть до merge | один большой uncommitted diff |
+| Слитые part-ветки после задачи | удалены (`make branch-cleanup`) | остались `feat/*`/`refactor/*` без `merged/` |
 
 Задача **не завершена**, пока: (a) не созданы все N part-веток по плану; (b) не слиты в `feat/<slug>`; (c) review не на интеграционной.
 

--- a/.cursor/skills/dnd-mud-git-pr/SKILL.md
+++ b/.cursor/skills/dnd-mud-git-pr/SKILL.md
@@ -82,7 +82,7 @@ git fetch origin --prune
 
 ```bash
 git fetch origin && git checkout dev && git merge --ff-only origin/dev
-make branch-cleanup   # git branch -d для всех веток, слитых в dev; merged/*, main, dev не трогает
+make branch-cleanup   # git branch -d для всех веток, слитых в CLEANUP_BASE (по умолчанию dev); merged/*, main, dev не трогает
 ```
 
 Не оставлять part-ветки без префикса `merged/` — они относятся к завершённой задаче и должны быть удалены (ручной `git branch -d` на каждую — источник ошибок; используй `make branch-cleanup`). Проверка «задача завершена» — [`dnd-mud-workflow.mdc`](../../rules/dnd-mud-workflow.mdc) §Проверка перед «задача завершена».

--- a/.cursor/skills/dnd-mud-git-pr/SKILL.md
+++ b/.cursor/skills/dnd-mud-git-pr/SKILL.md
@@ -75,3 +75,14 @@ git fetch origin --prune
 `main` и `dev` не переименовывать. Префикс `merged/` не дублировать.
 
 Если на `origin` остались legacy `merged/*` — удалить: `git push origin --delete merged/<name>`.
+
+## Чистка part-веток (обязательный финальный шаг)
+
+После merge всех part-веток в интеграционную (и после rename в `merged/*`) — **удалить локальные part-ветки**, слитые в `dev`, одной командой:
+
+```bash
+git fetch origin && git checkout dev && git merge --ff-only origin/dev
+make branch-cleanup   # git branch -d для всех веток, слитых в dev; merged/*, main, dev не трогает
+```
+
+Не оставлять part-ветки без префикса `merged/` — они относятся к завершённой задаче и должны быть удалены (ручной `git branch -d` на каждую — источник ошибок; используй `make branch-cleanup`). Проверка «задача завершена» — [`dnd-mud-workflow.mdc`](../../rules/dnd-mud-workflow.mdc) §Проверка перед «задача завершена».

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ PDF парсят только агенты. После правок — `python 
 ## Agent-loop
 
 ```
-git-старт (feat/<slug>) → [инвентаризация N PR из плана] → [part-ветка × N: checkout -b → scope → commit]* → merge all → feat/<slug> → docs → review → [fix-plan?] → push/PR → merged/…
+git-старт (feat/<slug>) → [инвентаризация N PR из плана] → [part-ветка × N: checkout -b → scope → commit]* → merge all (--no-ff) + branch-cleanup → feat/<slug> → docs → review → [fix-plan?] → push/PR → merged/…
 ```
 
 Part-ветки: **1 PR плана = 1 ветка**; N PR → N веток — [`dnd-mud-workflow.mdc`](.cursor/rules/dnd-mud-workflow.mdc) §Несколько веток. **`main` / `dev` не трогать**. Docs — [`dnd-mud-docs-after-task`](.cursor/skills/dnd-mud-docs-after-task/SKILL.md) перед commit финализации.
@@ -60,7 +60,8 @@ Personal: `git-dev-main-sync` (`~/.cursor/skills/git-dev-main-sync/`).
 | 0 | Инвентаризация веток из плана | Таблица PR → имя ветки; **N** = число `### PR-*` (или фаз delivery); до кода — [`dnd-mud-workflow.mdc`](.cursor/rules/dnd-mud-workflow.mdc) §Шаг 0 |
 | 1 | Git-старт | `feat/<slug>` от `dev`; [`01-operations.mdc`](~/.cursor/rules/01-operations.mdc) §Task cycle ш.1 |
 | 2 | Реализация | **Каждый PR** — `git checkout -b <branch>` → scope → commit; не следующий PR без commit на текущей part-ветке |
-| 2b | Слияние N part → `feat/<slug>` | После **всех** PR плана; `main`/`dev` не трогать |
+| 2b | Слияние N part → `feat/<slug>` | После **всех** PR плана; каждая part сразу `git branch -d` после `--no-ff` merge; `main`/`dev` не трогать |
+| 2c | Чистка слитых part-веток | `make branch-cleanup` (или `git branch -d` в цикле 2b); не оставлять `feat/*`/`refactor/*` без `merged/` |
 | 3–4 | Docs + commit финализации | skill [`dnd-mud-docs-after-task`](.cursor/skills/dnd-mud-docs-after-task/SKILL.md) |
 | 5 | Review (включает `verify-scope`) | skill [`dnd-mud-review`](.cursor/skills/dnd-mud-review/SKILL.md) — **один раз** |
 | 6 | Fix plan | skill [`dnd-mud-fix-plan`](.cursor/skills/dnd-mud-fix-plan/SKILL.md) |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help venv-recreate venv install install-hooks reinstall clean lint format format-check typecheck check test test-fast test-cov verify verify-changed verify-scope test-changed test-scope check-changed check-scope
+.PHONY: help venv-recreate venv install install-hooks reinstall clean lint format format-check typecheck check test test-fast test-cov verify verify-changed verify-scope test-changed test-scope check-changed check-scope branch-cleanup
 
 VENV      := .venv
 PYTHON    := python3.12
@@ -102,6 +102,22 @@ verify-changed: check-changed test-changed
 .PHONY: verify-scope
 verify-scope: check-scope test-scope
 
+# Удаляет локальные ветки, полностью слитые в dev (part-ветки после merge).
+# Безопасно: git branch -d не тронет не-слитые; архив merged/* и main/dev не трогаются.
+.PHONY: branch-cleanup
+branch-cleanup:
+	@cur=$$(git rev-parse --abbrev-ref HEAD); \
+	stale=$$(git branch --merged dev --format='%(refname:short)' \
+		| grep -vxE 'main|dev' \
+		| grep -v '^merged/' \
+		| grep -vx "$$cur"); \
+	if [ -z "$$stale" ]; then \
+		echo "Слитых part-веток нет — чисто."; \
+	else \
+		echo "Удаляю слитые в dev part-ветки:"; echo "$$stale"; \
+		echo "$$stale" | xargs -r -n1 git branch -d; \
+	fi
+
 .PHONY: help
 help:
 	@echo "Доступные команды:"
@@ -123,3 +139,4 @@ help:
 	@echo "  make verify-scope    — lint + test diff $(VERIFY_BASE)...HEAD (конец задачи)"
 	@echo "  make test-changed    — pytest только для staged изменений"
 	@echo "  make test-scope      — pytest для diff ветки vs $(VERIFY_BASE)"
+	@echo "  make branch-cleanup  — удалить локальные part-ветки, слитые в dev (кроме merged/*)"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PIP       := $(VENV)/bin/pip
 PYTHON_VENV := $(VENV)/bin/python
 VERIFY    := $(PYTHON_VENV) scripts/verify_targets.py
 VERIFY_BASE ?= origin/dev
+CLEANUP_BASE ?= dev
 
 $(VENV)/bin/python:
 	$(PYTHON) -m venv $(VENV)
@@ -102,19 +103,21 @@ verify-changed: check-changed test-changed
 .PHONY: verify-scope
 verify-scope: check-scope test-scope
 
-# Удаляет локальные ветки, полностью слитые в dev (part-ветки после merge).
+# Удаляет локальные ветки, полностью слитые в базу CLEANUP_BASE (по умолчанию dev; для §2b: make branch-cleanup CLEANUP_BASE=feat/<slug>).
 # Безопасно: git branch -d не тронет не-слитые; архив merged/* и main/dev не трогаются.
 .PHONY: branch-cleanup
 branch-cleanup:
+	@git rev-parse --verify --quiet $(CLEANUP_BASE) >/dev/null \
+		|| { echo "Базовая ветка '$(CLEANUP_BASE)' не найдена локально."; exit 1; }
 	@cur=$$(git rev-parse --abbrev-ref HEAD); \
-	stale=$$(git branch --merged dev --format='%(refname:short)' \
+	stale=$$(git branch --merged $(CLEANUP_BASE) --format='%(refname:short)' \
 		| grep -vxE 'main|dev' \
 		| grep -v '^merged/' \
 		| grep -vx "$$cur"); \
 	if [ -z "$$stale" ]; then \
-		echo "Слитых part-веток нет — чисто."; \
+		echo "Слитых в '$(CLEANUP_BASE)' part-веток нет — чисто."; \
 	else \
-		echo "Удаляю слитые в dev part-ветки:"; echo "$$stale"; \
+		echo "Удаляю слитые в '$(CLEANUP_BASE)' part-ветки:"; echo "$$stale"; \
 		echo "$$stale" | xargs -r -n1 git branch -d; \
 	fi
 
@@ -139,4 +142,4 @@ help:
 	@echo "  make verify-scope    — lint + test diff $(VERIFY_BASE)...HEAD (конец задачи)"
 	@echo "  make test-changed    — pytest только для staged изменений"
 	@echo "  make test-scope      — pytest для diff ветки vs $(VERIFY_BASE)"
-	@echo "  make branch-cleanup  — удалить локальные part-ветки, слитые в dev (кроме merged/*)"
+	@echo "  make branch-cleanup  — удалить локальные part-ветки, слитые в CLEANUP_BASE=$(CLEANUP_BASE) (кроме merged/*)"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - **DRY-рефакторинг (6 PR):** UI-хелперы `_print_pick_list` / `_read_pool_pick`, `apply_subclass_picks`, `bootstrap_session_catalogs`; core micro-DRY (`PHB_SKILL_IDS`, `iter_race_grants_by_source`, `_load_catalog_item`); save API через `build_new_character` + `persist_character` и `_CreationState.to_character()`; подпакеты `core/feats/`, `core/proficiencies/`, `core/progression/`; `Character.class_id` — `CharacterClass` (JSON — string; пустой `class_id` в JSON — ошибка)
 - **Load game:** `load_character_for_session` — единый путь загрузки персонажа через `character_storage._try_load_character_file`
 - **Git workflow:** Plan/Agent с part-ветками — обязательное создание веток, merge в `feat/<slug>`; `main`/`dev` в задаче не трогать
+- **Git workflow (tooling):** `make branch-cleanup` — удаление локальных part-веток, слитых в `CLEANUP_BASE` (по умолчанию `dev`; §2b — `CLEANUP_BASE=feat/<slug>`), с защитой `main`/`dev`/`merged/*` и guard на отсутствие базы; удаление part-ветки после `--no-ff` merge — явный шаг (`Makefile`, `dnd-mud-workflow.mdc`, `dnd-mud-git-pr`)
 - Skills refactor (DRY layers): policy verify/review — только `dnd-mud-workflow.mdc`; skills — процедуры; `AGENTS.md` / `DEVELOPMENT.md` — индекс ссылок
 - **Экран расы/подрасы:** выборный язык в строке «Языки»; подрасы без дубля grants родителя; полуорк всегда с экраном выбора и «Назад»
 - **Экран класса:** схлопнутый ASI по уровням; `proficiency_token_label` в меню владений и стартового снаряжения


### PR DESCRIPTION
## Summary
- Добавляет `make branch-cleanup` — удаляет локальные part-ветки, полностью слитые в базу `CLEANUP_BASE` (по умолчанию `dev`; в контексте §2b — `CLEANUP_BASE=feat/<slug>`), с защитой `main`/`dev`/`merged/*` и текущей ветки. `git branch -d` не трогает не-слитые.
- Guard: цель завершается с ошибкой, если базовая ветка отсутствует локально (раньше — ложное «чисто»).
- Делает удаление part-ветки после `--no-ff` merge **явным шагом** workflow (`dnd-mud-workflow.mdc` §2b/§2c, `AGENTS.md` steps 2b/2c, `dnd-mud-git-pr`).
- `docs/CHANGELOG.md` [Unreleased] — запись про новую tooling-цель и явный шаг.

## Изменённые файлы
- `Makefile` — цель `branch-cleanup` + `CLEANUP_BASE`, guard, `.PHONY`, help.
- `.cursor/rules/dnd-mud-workflow.mdc`, `AGENTS.md`, `.cursor/skills/dnd-mud-git-pr/SKILL.md` — явный шаг чистки + ссылки на `CLEANUP_BASE`.
- `docs/CHANGELOG.md` — [Unreleased].

## Test plan
- [x] `make branch-cleanup` (default `dev`) → «Слитых в 'dev' part-веток нет — чисто.»
- [x] `make branch-cleanup CLEANUP_BASE=no-such-branch` → ошибка + exit ≠ 0 (guard)
- [x] `make help` показывает `branch-cleanup` с базой
- [x] Фильтр защищает `main`/`dev`/`merged/*`/current (dry-run детекции)
- [x] pre-commit `verify-changed` (full lint + 256 tests) на коммите Makefile


Made with [Cursor](https://cursor.com)