### PR TITLE
fix: localize equipment choice labels and show item stats

### DIFF
--- a/core/catalogs/equipment.py
+++ b/core/catalogs/equipment.py
@@ -269,16 +269,22 @@ def weapon_matches_category(category: str, weapon_id: str) -> bool:
 
 from core.inventory.equipment_text import (  # noqa: E402
     armor_equipped_hint,
+    format_armor_list_ac,
     format_dice_for_display,
+    format_item_list_hint,
     format_versatile_catalog_hint,
+    format_weapon_list_damage,
     format_weapon_property_labels,
     weapon_property_hint,
 )
 
 __all__ = [
     "armor_equipped_hint",
+    "format_armor_list_ac",
     "format_dice_for_display",
+    "format_item_list_hint",
     "format_versatile_catalog_hint",
+    "format_weapon_list_damage",
     "format_weapon_property_labels",
     "weapon_property_hint",
 ]

--- a/core/inventory/equipment_text.py
+++ b/core/inventory/equipment_text.py
@@ -83,6 +83,46 @@ def weapon_property_hint(
     )
 
 
+def format_weapon_list_damage(weapon_id: str, language: str = "ru") -> str:
+    """Кубы урона для списка: 1к8 или 1к8/1к10 (универсальное)."""
+    one_dice = format_dice_for_display(weapon_damage_dice(weapon_id), language)
+    if "versatile" not in weapon_properties_raw(weapon_id):
+        return one_dice
+    two_dice = format_dice_for_display(
+        weapon_versatile_dice(weapon_id), language
+    )
+    return f"{one_dice}/{two_dice}"
+
+
+def format_armor_list_ac(
+    armor_id: str, strings: StringsDict, language: str = "ru"
+) -> str:
+    """КД/бонус КД для списка снаряжения."""
+    cat = armor_category(armor_id)
+    info = load_armor(armor_id)
+    if cat == "shield":
+        bonus = int(info.get("armor_class_bonus", 2))
+        return get_string(strings, "armor_list_hint.shield", bonus=bonus)
+    if cat not in ("light", "medium", "heavy"):
+        return ""
+    ac = int(info.get("armor_class", 10))
+    return get_string(strings, f"armor_list_hint.{cat}", ac=ac)
+
+
+def format_item_list_hint(
+    kind: str,
+    item_id: str,
+    strings: StringsDict,
+    language: str = "ru",
+) -> str:
+    """Механика предмета для списка: кубы урона или КД."""
+    if kind == "weapon":
+        return format_weapon_list_damage(item_id, language)
+    if kind == "armor":
+        return format_armor_list_ac(item_id, strings, language)
+    return ""
+
+
 def armor_equipped_hint(
     armor_id: str, strings: StringsDict, language: str = "ru"
 ) -> str:

--- a/core/inventory/starting_equipment.py
+++ b/core/inventory/starting_equipment.py
@@ -57,6 +57,12 @@ STARTING_EQUIPMENT_SECTION_KEYS: dict[str, str] = {
 }
 
 
+def equipment_choice_label(choice_id: str, strings: StringsDict) -> str:
+    """Локализованная подпись группы выбора стартового снаряжения."""
+    label = get_string(strings, f"equipment_choice.{choice_id}", default="")
+    return label or choice_id
+
+
 def get_class_starting_equipment_config(class_id: str) -> dict[str, Any]:
     """Конфиг стартового снаряжения класса."""
     info = get_class_dict(class_id)

--- a/database/strings/en.yaml
+++ b/database/strings/en.yaml
@@ -53,7 +53,7 @@ character:
   class_starting_equipment_choice: "      • {label}"
   equipment_caption: "CLASS STARTING EQUIPMENT"
   equipment_fixed_heading: "  Fixed gear:"
-  equipment_choice_heading: "Choice: {id}"
+  equipment_choice_heading: "Choice: {label}"
   equipment_option_prompt: "Choose option: "
   equipment_weapon_pick: "WEAPON CHOICE"
   equipment_weapon_prompt: "Choose weapon: "
@@ -465,6 +465,23 @@ armor_equipped_hint:
   heavy: "{category}, AC {ac}"
   strength: "Str {value}"
   stealth: "stealth disadvantage"
+
+armor_list_hint:
+  light: "AC {ac} + Dex"
+  medium: "AC {ac} + Dex, max 2"
+  heavy: "AC {ac}"
+  shield: "+{bonus} AC"
+
+equipment_choice:
+  melee: "melee"
+  ranged: "ranged"
+  armor: "armor"
+  weapon: "weapon"
+  weapon_primary: "primary weapon"
+  ranged_or_axes: "ranged or handaxes"
+  pack: "pack"
+  instrument: "instrument"
+  focus: "focus"
 
 weapon_property:
   light: "light"

--- a/database/strings/ru.yaml
+++ b/database/strings/ru.yaml
@@ -53,7 +53,7 @@ character:
   class_starting_equipment_choice: "      • {label}"
   equipment_caption: "СТАРТОВОЕ СНАРЯЖЕНИЕ КЛАССА"
   equipment_fixed_heading: "  Фиксированное снаряжение:"
-  equipment_choice_heading: "Выбор: {id}"
+  equipment_choice_heading: "Выбор: {label}"
   equipment_option_prompt: "Выберите вариант: "
   equipment_weapon_pick: "ВЫБОР ОРУЖИЯ"
   equipment_weapon_prompt: "Выберите оружие: "
@@ -465,6 +465,23 @@ armor_equipped_hint:
   heavy: "{category}, КД {ac}"
   strength: "Сил {value}"
   stealth: "помеха скрытности"
+
+armor_list_hint:
+  light: "КД {ac} + Лов"
+  medium: "КД {ac} + Лов, макс. 2"
+  heavy: "КД {ac}"
+  shield: "+{bonus} КД"
+
+equipment_choice:
+  melee: "ближний бой"
+  ranged: "дальний бой"
+  armor: "доспехи"
+  weapon: "оружие"
+  weapon_primary: "основное оружие"
+  ranged_or_axes: "дальний бой или топоры"
+  pack: "набор"
+  instrument: "инструмент"
+  focus: "фокус"
 
 weapon_property:
   light: "лёгкое"

--- a/docs/API.md
+++ b/docs/API.md
@@ -494,11 +494,16 @@ Leaf-модули: `items`, `armor_class`, `equip_defaults`, `equipped_display`,
 add_items_to_inventory(inventory, new_items) -> list[dict]
 equip_defaults(character: Character) -> dict[str, Any]
 compute_ac(character: Character) -> int
-format_inventory_line(inventory, language="ru") -> str
+# core.inventory.equipment_text
+format_weapon_list_damage(weapon_id, language="ru") -> str
+format_armor_list_ac(armor_id, strings, language="ru") -> str
+format_item_list_hint(kind, item_id, strings, language="ru") -> str
 # core.inventory.equipped_display
 get_equipped_display(character, language="ru") -> dict[str, str]
 # core.inventory.background_equipment
 get_background_equipment_items(background_id, background_tool_picks=None) -> list
+# ui.menus.display.equipment_view
+format_inventory_line(inventory, language="ru", *, equipped=None) -> str
 ```
 
 ---
@@ -509,6 +514,7 @@ get_background_equipment_items(background_id, background_tool_picks=None) -> lis
 
 ```python
 get_class_starting_equipment_config(class_id: str) -> dict
+equipment_choice_label(choice_id, strings) -> str
 resolve_starting_items(class_id, choices, weapon_proficiencies, armor_proficiencies) -> list[dict]
 filter_available_options(class_id, weapon_proficiencies, armor_proficiencies) -> dict
 weapons_for_pool(pool: str, weapon_proficiencies: list[str]) -> list[str]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,7 +111,7 @@ UI не читает файлы данных напрямую — только �
 | `inventory/items.py` | Операции с инвентарём |
 | `inventory/armor_class.py` | Расчёт КД |
 | `inventory/background_equipment.py` | Снаряжение предыстории |
-| `inventory/equipment_text.py` | UI-подсказки оружия/доспехов |
+| `inventory/equipment_text.py` | UI-подсказки оружия/доспехов (свойства, кубы урона, КД в списках) |
 | `inventory/equipped_display.py` | Данные экипировки для карточки (`get_equipped_display`) |
 | `inventory/equip_defaults.py` | Авто-экипировка |
 | `inventory/starting_equipment.py` | Стартовое снаряжение класса из YAML |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Code slim refactor:** purge мёртвого API; `core/combat.py` вместо пакета; `ui/menus/display/` вместо `_display` god-file; `core/hp_bonus.py` + `core/expertise.py` sibling-модули; dedupe UI picks / scenario checks; slim `character_build`
 
 ### Fixed
+- **Снаряжение UI:** заголовки выбора групп (`melee`/`ranged`/…) локализованы; в списках инвентаря и стартового снаряжения у оружия — кубы урона, у доспехов/щитов — КД
 - **Mod gating:** после сессии приключения `reset_session_catalogs()` возвращает gating к `normal` (`new_game` / `load_game`)
 
 ### Removed

--- a/tests/core/inventory/test_inventory.py
+++ b/tests/core/inventory/test_inventory.py
@@ -423,6 +423,7 @@ def test_format_inventory_line_omits_equipped() -> None:
     inventory: list[InventoryItem] = [
         {"kind": "armor", "id": "leather", "qty": 1},
         {"kind": "weapon", "id": "rapier", "qty": 1},
+        {"kind": "weapon", "id": "dagger", "qty": 2},
         {"kind": "tool", "id": "lute", "qty": 1},
     ]
     equipped: EquippedState = {
@@ -433,4 +434,17 @@ def test_format_inventory_line_omits_equipped() -> None:
     line = format_inventory_line(inventory, "ru", equipped=equipped)
     assert "Кожаный доспех" not in line
     assert "Рапира" not in line
+    assert "Кинжал (1к4) ×2" in line
     assert "Лютня" in line
+
+
+def test_format_inventory_line_shows_weapon_and_armor_stats() -> None:
+    inventory: list[InventoryItem] = [
+        {"kind": "weapon", "id": "longsword", "qty": 1},
+        {"kind": "armor", "id": "chain_mail", "qty": 1},
+        {"kind": "armor", "id": "shield", "qty": 1},
+    ]
+    line = format_inventory_line(inventory, "ru")
+    assert "Длинный меч (1к8/1к10)" in line
+    assert "Кольчуга (КД 16)" in line
+    assert "Щит (+2 КД)" in line

--- a/tests/core/inventory/test_starting_equipment.py
+++ b/tests/core/inventory/test_starting_equipment.py
@@ -6,6 +6,7 @@ import pytest
 
 from core.inventory.starting_equipment import (
     all_weapons_in_pool,
+    equipment_choice_label,
     equipment_option_available,
     equipment_option_strength_warning,
     format_equipment_option_label,
@@ -31,6 +32,16 @@ def test_all_weapons_in_pool_includes_non_proficient() -> None:
     proficient = weapons_for_pool("simple", ["club"])
     assert "club" in all_simple
     assert len(all_simple) > len(proficient)
+
+
+def test_equipment_choice_label_localizes_melee(
+    ru_strings: dict[str, Any],
+) -> None:
+    assert equipment_choice_label("melee", ru_strings) == "ближний бой"
+    assert equipment_choice_label("ranged", ru_strings) == "дальний бой"
+    assert equipment_choice_label("unknown_group", ru_strings) == (
+        "unknown_group"
+    )
 
 
 def test_format_equipment_option_label_armor_hints(

--- a/ui/menus/creation/equipment.py
+++ b/ui/menus/creation/equipment.py
@@ -6,13 +6,16 @@ from typing import Any
 from colorama import Fore, Style
 
 from core.catalogs.equipment import (
+    format_item_list_hint,
     format_versatile_catalog_hint,
+    format_weapon_list_damage,
     get_tool_name,
     get_weapon_name,
     weapon_property_hint,
 )
 from core.inventory.starting_equipment import (
     all_weapons_in_pool,
+    equipment_choice_label,
     equipment_option_available,
     equipment_option_strength_warning,
     format_equipment_option_label,
@@ -67,16 +70,21 @@ def _format_weapon_menu_label(
     strings: StringsDict,
     language: str,
 ) -> str:
-    """Подпись оружия в меню: имя + свойства PHB серым."""
+    """Подпись оружия в меню: имя + кубы урона / свойства PHB серым."""
     name = get_weapon_name(weapon_id, language)
     line = format_pick_menu_label(name, proficient)
+    parts: list[str] = []
     catalog = format_versatile_catalog_hint(weapon_id, strings, language)
     if catalog:
-        line += f" {Fore.LIGHTBLACK_EX}({catalog}){Style.RESET_ALL}"
+        parts.append(catalog)
     else:
-        hint = weapon_property_hint(weapon_id, strings, language)
-        if hint:
-            line += f" {Fore.LIGHTBLACK_EX}({hint}){Style.RESET_ALL}"
+        parts.append(format_weapon_list_damage(weapon_id, language))
+    prop_hint = weapon_property_hint(weapon_id, strings, language)
+    if prop_hint:
+        parts.append(prop_hint)
+    if parts:
+        joined = ", ".join(parts)
+        line += f" {Fore.LIGHTBLACK_EX}({joined}){Style.RESET_ALL}"
     return line
 
 
@@ -165,7 +173,11 @@ def _pick_option_for_group(
         )
     ]
     print_screen_header(
-        get_string(strings, "character.equipment_choice_heading", id=choice_id)
+        get_string(
+            strings,
+            "character.equipment_choice_heading",
+            label=equipment_choice_label(choice_id, strings),
+        )
     )
     for opt in options:
         label = _format_equipment_menu_label(opt, strings, language, strength)
@@ -241,6 +253,9 @@ def select_creation_equipment(
                 from core.catalogs.equipment import get_equipment_item_name
 
                 name = get_equipment_item_name(item_id, language)
+            mech = format_item_list_hint(kind, item_id, strings, language)
+            if mech:
+                name = f"{name} ({mech})"
             line = f"  {Fore.CYAN}• {name}{Style.RESET_ALL}"
             if qty > 1:
                 line += f" {Fore.LIGHTBLACK_EX}×{qty}{Style.RESET_ALL}"

--- a/ui/menus/display/equipment_view.py
+++ b/ui/menus/display/equipment_view.py
@@ -2,6 +2,7 @@
 
 from colorama import Fore, Style
 
+from core.catalogs.equipment import format_item_list_hint
 from core.character.models import Character
 from core.inventory.armor_class import compute_ac
 from core.inventory.equipped_display import get_equipped_display
@@ -9,7 +10,7 @@ from core.inventory.items import (
     inventory_excluding_equipped,
     item_display_name,
 )
-from core.platform.localization import get_string
+from core.platform.localization import get_string, load_strings
 from core.types import EquippedState, InventoryItem, StringsDict
 from ui.menus.display.shared import _print_labeled_field
 
@@ -115,6 +116,7 @@ def format_inventory_line(
     equipped: EquippedState | None = None,
 ) -> str:
     """Сжатый список инвентаря для UI (без экипированных предметов)."""
+    strings = load_strings(language)
     display_items = inventory_excluding_equipped(inventory, equipped)
     parts: list[str] = []
     for item in display_items:
@@ -122,6 +124,9 @@ def format_inventory_line(
         item_id = str(item.get("id", ""))
         qty = int(item.get("qty", 1))
         name = item_display_name(kind, item_id, language)
+        hint = format_item_list_hint(kind, item_id, strings, language)
+        if hint:
+            name = f"{name} ({hint})"
         if qty > 1:
             parts.append(f"{name} ×{qty}")
         else:


### PR DESCRIPTION
## Summary
- Локализует заголовки выбора снаряжения (`melee`/`ranged` → «ближний бой» / «дальний бой»).
- В списках снаряжения показывает куб урона и/или КД (оружие, доспехи, щиты).
- Обновлены строки локализации, хелперы форматирования, UI создания/карточки и тесты.

## Test plan
- [x] `make verify-scope` на task-ветке
- [ ] Smoke: создать персонажа и пройти выбор оружия — заголовок на русском
- [ ] В списке снаряжения видны кубы/КД у оружия и брони


Made with [Cursor](https://cursor.com)