### PR TITLE
feat: character creation draft and Continue menu

### DIFF
--- a/core/character/creation_draft.py
+++ b/core/character/creation_draft.py
@@ -1,0 +1,234 @@
+"""Черновик незавершённого создания персонажа."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from core.platform.io import load_json, save_json
+from core.types import GameDifficulty, StatMap
+
+logger = logging.getLogger(__name__)
+
+CREATION_DRAFT_SCHEMA_VERSION = 1
+CREATION_DRAFT_PATH = Path("saves") / "creation_draft.json"
+
+CreationStep = Literal[
+    "race",
+    "subrace",
+    "languages",
+    "stats",
+    "background",
+    "feats",
+    "class",
+    "subclass",
+    "proficiencies",
+    "skills",
+    "expertise",
+    "equipment",
+]
+
+_VALID_STEPS: frozenset[str] = frozenset(
+    {
+        "race",
+        "subrace",
+        "languages",
+        "stats",
+        "background",
+        "feats",
+        "class",
+        "subclass",
+        "proficiencies",
+        "skills",
+        "expertise",
+        "equipment",
+    }
+)
+
+
+@dataclass
+class CreationDraft:
+    """Снимок незавершённого создания персонажа для JSON."""
+
+    current_step: CreationStep
+    name: str
+    difficulty: GameDifficulty
+    race_id: str | None = None
+    subrace_id: str | None = None
+    languages: list[str] | None = None
+    stats: StatMap | None = None
+    background_id: str | None = None
+    background_skills: list[str] = field(default_factory=list)
+    class_id: str | None = None
+    subclass_id: str | None = None
+    skills: list[str] | None = None
+    skill_expertise: list[str] | None = None
+    tool_expertise: list[str] | None = None
+    weapon_proficiencies: list[str] | None = None
+    armor_proficiencies: list[str] | None = None
+    tool_proficiencies: list[str] | None = None
+    background_tool_picks: list[str] = field(default_factory=list)
+    equipment_choices: dict[str, str] = field(default_factory=dict)
+    feat_ids: list[str] = field(default_factory=list)
+    feat_choices: dict[str, dict[str, Any]] = field(default_factory=dict)
+    hardcore_rolls: list[int] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Сериализация в JSON."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CreationDraft | None:
+        """Десериализация; ``None`` при невалидных обязательных полях."""
+        step_raw = data.get("current_step")
+        name = data.get("name")
+        if not isinstance(step_raw, str) or step_raw not in _VALID_STEPS:
+            return None
+        if not isinstance(name, str) or not name.strip():
+            return None
+        difficulty = _parse_difficulty(data.get("difficulty", "normal"))
+        stats = _parse_stats(data.get("stats"))
+        return cls(
+            current_step=cast(CreationStep, step_raw),
+            name=name.strip(),
+            difficulty=difficulty,
+            race_id=_optional_str(data.get("race_id")),
+            subrace_id=_optional_str(data.get("subrace_id")),
+            languages=_optional_str_list(data.get("languages")),
+            stats=stats,
+            background_id=_optional_str(data.get("background_id")),
+            background_skills=_str_list(data.get("background_skills")),
+            class_id=_optional_str(data.get("class_id")),
+            subclass_id=_optional_str(data.get("subclass_id")),
+            skills=_optional_str_list(data.get("skills")),
+            skill_expertise=_optional_str_list(data.get("skill_expertise")),
+            tool_expertise=_optional_str_list(data.get("tool_expertise")),
+            weapon_proficiencies=_optional_str_list(
+                data.get("weapon_proficiencies")
+            ),
+            armor_proficiencies=_optional_str_list(
+                data.get("armor_proficiencies")
+            ),
+            tool_proficiencies=_optional_str_list(
+                data.get("tool_proficiencies")
+            ),
+            background_tool_picks=_str_list(data.get("background_tool_picks")),
+            equipment_choices=_str_str_dict(data.get("equipment_choices")),
+            feat_ids=_str_list(data.get("feat_ids")),
+            feat_choices=_feat_choices(data.get("feat_choices")),
+            hardcore_rolls=_int_list(data.get("hardcore_rolls")),
+        )
+
+
+def _parse_difficulty(raw: object) -> GameDifficulty:
+    if raw == "hardcore":
+        return "hardcore"
+    if raw == "easy":
+        return "easy"
+    return "normal"
+
+
+def _optional_str(raw: object) -> str | None:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        return raw
+    return str(raw)
+
+
+def _optional_str_list(raw: object) -> list[str] | None:
+    if raw is None:
+        return None
+    return _str_list(raw)
+
+
+def _str_list(raw: object) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    return [str(item) for item in raw]
+
+
+def _int_list(raw: object) -> list[int]:
+    if not isinstance(raw, list):
+        return []
+    result: list[int] = []
+    for item in raw:
+        try:
+            result.append(int(item))
+        except (TypeError, ValueError):
+            continue
+    return result
+
+
+def _str_str_dict(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): str(value) for key, value in raw.items()}
+
+
+def _feat_choices(raw: object) -> dict[str, dict[str, Any]]:
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for key, value in raw.items():
+        if isinstance(value, dict):
+            result[str(key)] = dict(value)
+    return result
+
+
+def _parse_stats(raw: object) -> StatMap | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    required = ("str", "dex", "con", "int", "wis", "cha")
+    try:
+        return {key: int(raw[key]) for key in required}
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def has_creation_draft(path: Path | None = None) -> bool:
+    """Есть ли валидный черновик создания на диске."""
+    return load_creation_draft(path) is not None
+
+
+def load_creation_draft(path: Path | None = None) -> CreationDraft | None:
+    """Загрузить черновик; битый файл удаляется."""
+    draft_path = path if path is not None else CREATION_DRAFT_PATH
+    if not draft_path.exists():
+        return None
+    try:
+        data = load_json(draft_path)
+        draft = CreationDraft.from_dict(data)
+        if draft is None:
+            logger.warning("Невалидный черновик создания: %s", draft_path)
+            clear_creation_draft(draft_path)
+            return None
+        return draft
+    except (OSError, ValueError, TypeError) as exc:
+        logger.warning("Не удалось прочитать черновик %s: %s", draft_path, exc)
+        clear_creation_draft(draft_path)
+        return None
+
+
+def save_creation_draft(
+    draft: CreationDraft, path: Path | None = None
+) -> None:
+    """Сохранить черновик создания."""
+    draft_path = path if path is not None else CREATION_DRAFT_PATH
+    draft_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = draft.to_dict()
+    payload["schema_version"] = CREATION_DRAFT_SCHEMA_VERSION
+    save_json(draft_path, payload)
+
+
+def clear_creation_draft(path: Path | None = None) -> None:
+    """Удалить файл черновика, если он есть."""
+    draft_path = path if path is not None else CREATION_DRAFT_PATH
+    with contextlib.suppress(OSError):
+        if draft_path.exists():
+            draft_path.unlink()

--- a/core/character/creation_draft.py
+++ b/core/character/creation_draft.py
@@ -8,6 +8,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal, cast
 
+from core.mechanics.stats import STAT_NAMES
 from core.platform.io import load_json, save_json
 from core.types import GameDifficulty, StatMap
 
@@ -184,9 +185,8 @@ def _parse_stats(raw: object) -> StatMap | None:
         return None
     if not isinstance(raw, dict):
         return None
-    required = ("str", "dex", "con", "int", "wis", "cha")
     try:
-        return {key: int(raw[key]) for key in required}
+        return {key: int(raw[key]) for key in STAT_NAMES}
     except (KeyError, TypeError, ValueError):
         return None
 

--- a/database/strings/en.yaml
+++ b/database/strings/en.yaml
@@ -6,6 +6,7 @@ welcome:
 
 menu:
   caption: "MAIN MENU"
+  continue_creation: "Continue"
   new_game: "New Game"
   load_game: "Load Game"
   characters: "Characters"
@@ -411,6 +412,7 @@ level_up:
 errors:
   invalid_input: "Error: enter a number from {min} to {max}"
   invalid_number: "Error: enter a number from {min} to {max}"
+  ctrl_c_ignored: "Ctrl+C is disabled. Use the menu to exit."
   load_not_implemented: "Load game is not yet implemented"
 
 info:

--- a/database/strings/ru.yaml
+++ b/database/strings/ru.yaml
@@ -6,6 +6,7 @@ welcome:
 
 menu:
   caption: "ГЛАВНОЕ МЕНЮ"
+  continue_creation: "Продолжить"
   new_game: "Новая игра"
   load_game: "Загрузить игру"
   characters: "Персонажи"
@@ -411,6 +412,7 @@ level_up:
 errors:
   invalid_input: "Ошибка: введите число от {min} до {max}"
   invalid_number: "Ошибка: введите число от {min} до {max}"
+  ctrl_c_ignored: "Ctrl+C отключён. Для выхода используйте меню."
   load_not_implemented: "Загрузка игры ещё не реализована"
 
 info:

--- a/docs/API.md
+++ b/docs/API.md
@@ -812,6 +812,21 @@ load_character_for_session(snapshot, characters_dir) -> Character | None
 
 ---
 
+## core.character.creation_draft — Черновик создания
+
+```python
+CreationStep  # Literal шагов FSM
+CreationDraft  # current_step + поля состояния создания
+has_creation_draft(path=None) -> bool
+load_creation_draft(path=None) -> CreationDraft | None
+save_creation_draft(draft: CreationDraft, path=None) -> None
+clear_creation_draft(path=None) -> None
+```
+
+Файл: `saves/creation_draft.json` — см. [DATA_SCHEMA.md](DATA_SCHEMA.md) §Save JSON — черновик создания персонажа.
+
+---
+
 ## core.engine.difficulty — Режим сложности и приключения
 
 ```python
@@ -983,13 +998,16 @@ main() -> int
 
 | № | Пункт | Обработчик |
 |---|-------|------------|
-| 1 | Новая игра | `show_new_game_flow` |
-| 2 | Загрузить игру | `show_load_game_flow` |
-| 3 | Персонажи | `show_characters_menu` |
-| 4 | Настройки | `show_settings` |
-| 5 | Languages / Языки (кросс-локально) | `show_languages_menu` |
-| 6 | Модификации | `show_mods_menu` |
+| 1* | Продолжить | `show_continue_character_flow` (если есть черновик) |
+| 1/2 | Новая игра | `show_new_game_flow` |
+| 2/3 | Загрузить игру | `show_load_game_flow` |
+| 3/4 | Персонажи | `show_characters_menu` |
+| 4/5 | Настройки | `show_settings` |
+| 5/6 | Languages / Языки (кросс-локально) | `show_languages_menu` |
+| 6/7 | Модификации | `show_mods_menu` |
 | 0 | Выход | завершение |
+
+Номера сдвигаются при «Продолжить». `main.py` диспатчит по **action id** (`continue`, `new_game`, …).
 
 После изменения настроек или языка вызывается `_save_and_reload_settings`.
 
@@ -999,19 +1017,21 @@ main() -> int
 
 ```python
 show_welcome_screen(version: str, strings: dict) -> None
-show_main_menu(strings: dict) -> int
+show_main_menu(strings: dict, *, has_creation_draft: bool = False) -> str
 select_difficulty(strings: dict) -> str | None
 show_new_game_flow(strings: dict, settings: dict) -> None
 show_load_game_flow(strings: dict, language: str = "ru") -> None
 show_characters_menu(strings: dict, language: str = "ru") -> None
 show_mods_menu(strings: dict, language: str = "ru") -> None
-show_create_character_flow(strings: dict, language: str = "ru") -> Character | None  # ui/menus/creation/steps.py; из hub «Персонажи»
+show_create_character_flow(strings: dict, language: str = "ru") -> Character | None
+show_continue_character_flow(strings: dict, language: str = "ru") -> Character | None
 show_stats_generation_flow(strings: StringsDict, race_id: str, subrace_id: str | None, difficulty: GameDifficulty) -> StatMap | None
 show_settings(strings: dict, settings: dict) -> dict
 show_languages_menu(strings: dict, settings: dict) -> dict
 ```
 
 Создание персонажа: сложность → имя → раса → подраса → **характеристики** → **предыстория** → **языки** → класс → подкласс → **владения** → **навыки** → (компетентность?) → сохранение.  
+Между шагами — `saves/creation_draft.json`; аварийный выход → пункт «Продолжить». Ctrl+C на вводе игнорируется.  
 Режимы сложности: `easy`, `normal`, `hardcore`. HardCore — ключевой режим для механики, приключений и модов.  
 Подробности: [MUD_PRD.md §3.2.1](MUD_PRD.md#321-режимы-сложности-игры), [§3.4](MUD_PRD.md#34-flow-создать-персонажа).
 
@@ -1020,6 +1040,7 @@ show_languages_menu(strings: dict, settings: dict) -> dict
 ## ui.input_handler — Ввод
 
 ```python
+safe_input(prompt: str, strings: dict | None = None) -> str
 get_int_input(prompt: str, min_val: int, max_val: int, strings: dict | None = None) -> int
 get_str_input(prompt: str, min_length: int = 1, only_letters: bool = False, strings: dict | None = None) -> str
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,6 +93,7 @@ UI не читает файлы данных напрямую — только �
 | `character/finalize.py` | Merge языков черт + persist собранного персонажа |
 | `character/migrate.py` | `CHARACTERS_SCHEMA_VERSION`, `migrate_character_data` |
 | `character/storage.py` | CRUD; `make_save_slug`, `unique_save_slug`; JSON в `saves/` |
+| `character/creation_draft.py` | Черновик создания (`saves/creation_draft.json`) |
 | **`core/feats/`** | Черты (leaf: catalog, apply, text, requirements) |
 | `feats/catalog.py` | YAML черт, чистое чтение grants |
 | `feats/grant_merge.py` | Слияние черт с `ResolvedGrants` (над leaf resolve) |
@@ -154,6 +155,7 @@ UI не читает файлы данных напрямую — только �
 | `database/core/mods_state.json` | Включённые моды | JSON | `platform/mod_loader.py` |
 | `database/strings/*.yaml` | Локализация | YAML | `platform/localization.py` |
 | `saves/characters/*.json` | Персонажи (по одному файлу) | JSON | `character/storage.py` |
+| `saves/creation_draft.json` | Черновик незавершённого создания | JSON | `character/creation_draft.py` |
 | `saves/sessions/*.json` | Сессии приключений (узел сценария, флаги) | JSON | `engine/session_storage.py` |
 
 ### 4. Resources (`adventures/`, `mods/`)
@@ -193,7 +195,8 @@ main.py → ui/menus/ → core.<pkg>.<module> (прямые leaf-imports)
 
 **Сценарий «Создать персонажа»:** сложность → имя → раса → подраса → характеристики → предыстория → языки → класс → подкласс → черты (если нужны) → владения → навыки → (компетентность?) → **снаряжение** → сохранение в `saves/characters/{save_slug}.json`.
 
-- Оркестрация: `ui/menus/creation/steps.py` (`show_create_character_flow`), `ui/menus/creation/handlers.py`, `ui/menus/stats/stats_flow.py`
+- Оркестрация: `ui/menus/creation/steps.py` (`show_create_character_flow` / `show_continue_character_flow`), autosave в `saves/creation_draft.json`; `ui/menus/creation/handlers.py`, `ui/menus/stats/stats_flow.py`
+- Ввод: `ui/input_handler.safe_input` глотает Ctrl+C; safety-net в `main()`
 - Снаряжение: `ui/menus/creation/equipment.py` → `core.inventory.starting_equipment`; предыстория — `core.inventory.background_equipment.get_background_equipment_items`; merge и `equip_defaults` — `core.character.build.build_new_character` / `character.storage.persist_character`, `core.inventory.*`
 - Сохранение: `_CreationState.to_character()` → `persist_character()` (без kwargs-bridge)
 - Генераторы: `core.mechanics.stats`, `core.catalogs.races`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Черновик создания персонажа:** `saves/creation_draft.json`, пункт «Продолжить» в главном меню; autosave между шагами; Ctrl+C на вводе игнорируется (`safe_input` + safety-net в `main`)
+
 ### Changed
 - **Clean Code architecture pass:** `Adventure` → `catalogs/adventure`; background gear → `inventory/background_equipment`; racial HP → `mechanics/hp_bonus`; mod gating API → `CatalogSession`; `proficiency_collect` + `feats/grant_merge` (leaf `grants.resolve`); grant format registry; `equipment_text` / `equipped_display`; UI pool-pick helpers (`SCREEN_WIDTH`, `pick_from_pool_loop`)
 - **Spell cards fix:** восстановлены пустые `## Эффект` (23); `major_image` → `magic_mouth`; словари RU↔EN дополнены

--- a/docs/DATA_SCHEMA.md
+++ b/docs/DATA_SCHEMA.md
@@ -184,6 +184,25 @@ explorers_pack:
 | `equipped` | object | `armor`, `shield`, `main_hand`, `off_hand`, `main_hand_grip` |
 | `equipment_choices` | `{ choice_id: option_id }` | Аудит выборов а/б при создании |
 
+## Save JSON — черновик создания персонажа
+
+Файл `saves/creation_draft.json` (`CreationDraft`, `core/character/creation_draft.py`). Один черновик на установку: появляется при незавершённом создании (закрытие терминала / kill); пункт «Продолжить» в главном меню.
+
+| Ключ | Тип | Описание |
+|------|-----|----------|
+| `schema_version` | `int` | Версия схемы (сейчас `1`) |
+| `current_step` | `string` | Шаг FSM: `race`, `subrace`, `stats`, … `equipment` |
+| `name` | `string` | Имя персонажа |
+| `difficulty` | `normal` \| `hardcore` \| `easy` | Сложность |
+| `race_id` / `subrace_id` / `class_id` / … | `string \| null` | Поля выбора (как в `_CreationState`) |
+| `stats` | `object \| null` | `{ str, dex, con, int, wis, cha }` |
+| `languages` / `skills` / … | `string[] \| null` | Списки выборов |
+| `equipment_choices` | `{ choice_id: option_id }` | Выборы стартового снаряжения |
+| `feat_ids` / `feat_choices` | `string[]` / `object` | Черты при создании |
+| `hardcore_rolls` | `int[]` | Броски HardCore |
+
+Битый файл удаляется при загрузке. Успешный create / осознанная отмена — `clear_creation_draft()`.
+
 ## Save JSON — сессия приключения
 
 Файлы `saves/sessions/{save_slug}.json` (`SessionSnapshot`, `core/session_storage.py`). `save_slug` обычно `{character_save_slug}_{adventure_id}`.

--- a/docs/DATA_SCHEMA.md
+++ b/docs/DATA_SCHEMA.md
@@ -195,7 +195,7 @@ explorers_pack:
 | `name` | `string` | Имя персонажа |
 | `difficulty` | `normal` \| `hardcore` \| `easy` | Сложность |
 | `race_id` / `subrace_id` / `class_id` / … | `string \| null` | Поля выбора (как в `_CreationState`) |
-| `stats` | `object \| null` | `{ str, dex, con, int, wis, cha }` |
+| `stats` | `object \| null` | `{ strength, dexterity, constitution, intelligence, wisdom, charisma }` |
 | `languages` / `skills` / … | `string[] \| null` | Списки выборов |
 | `equipment_choices` | `{ choice_id: option_id }` | Выборы стартового снаряжения |
 | `feat_ids` / `feat_choices` | `string[]` / `object` | Черты при создании |

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from colorama import Fore, Style, init
 
+from core.character.creation_draft import has_creation_draft
 from core.platform.catalog_session import get_catalog_session
 from core.platform.localization import get_string, load_strings
 from core.platform.settings import load_settings, save_settings
@@ -25,6 +26,7 @@ from ui.menus import (
     show_settings,
     show_welcome_screen,
 )
+from ui.menus.creation.steps import show_continue_character_flow
 
 _PROJECT_ROOT = Path(__file__).resolve().parent
 
@@ -68,6 +70,14 @@ def _save_and_reload_settings(
     return settings, strings
 
 
+def _print_ctrl_c_ignored(strings: StringsDict) -> None:
+    print(
+        f"{Fore.YELLOW}"
+        f"{get_string(strings, 'errors.ctrl_c_ignored')}"
+        f"{Style.RESET_ALL}"
+    )
+
+
 def main() -> int:
     """Запустить игру.
 
@@ -91,39 +101,50 @@ def main() -> int:
     # Главный цикл меню
     running = True
     while running:
-        choice = show_main_menu(strings)
+        try:
+            action = show_main_menu(
+                strings, has_creation_draft=has_creation_draft()
+            )
 
-        match choice:
-            case 0:
-                print(
-                    f"{Fore.GREEN}{get_string(strings, 'info.goodbye')}"
-                    f"{Style.RESET_ALL}"
-                )
-                running = False
-            case 1:
-                show_new_game_flow(strings, settings)
-                settings, strings = _save_and_reload_settings(
-                    settings, strings
-                )
-            case 2:
-                show_load_game_flow(strings, settings["language"])
-            case 3:
-                show_characters_menu(strings, settings["language"])
-                settings, strings = _save_and_reload_settings(
-                    settings, strings
-                )
-            case 4:
-                settings = show_settings(strings, settings)
-                settings, strings = _save_and_reload_settings(
-                    settings, strings
-                )
-            case 5:
-                settings = show_languages_menu(strings, settings)
-                settings, strings = _save_and_reload_settings(
-                    settings, strings
-                )
-            case 6:
-                show_mods_menu(strings, settings["language"])
+            match action:
+                case "exit":
+                    print(
+                        f"{Fore.GREEN}{get_string(strings, 'info.goodbye')}"
+                        f"{Style.RESET_ALL}"
+                    )
+                    running = False
+                case "continue":
+                    show_continue_character_flow(strings, settings["language"])
+                    settings, strings = _save_and_reload_settings(
+                        settings, strings
+                    )
+                case "new_game":
+                    show_new_game_flow(strings, settings)
+                    settings, strings = _save_and_reload_settings(
+                        settings, strings
+                    )
+                case "load_game":
+                    show_load_game_flow(strings, settings["language"])
+                case "characters":
+                    show_characters_menu(strings, settings["language"])
+                    settings, strings = _save_and_reload_settings(
+                        settings, strings
+                    )
+                case "settings":
+                    settings = show_settings(strings, settings)
+                    settings, strings = _save_and_reload_settings(
+                        settings, strings
+                    )
+                case "languages":
+                    settings = show_languages_menu(strings, settings)
+                    settings, strings = _save_and_reload_settings(
+                        settings, strings
+                    )
+                case "mods":
+                    show_mods_menu(strings, settings["language"])
+        except KeyboardInterrupt:
+            print()
+            _print_ctrl_c_ignored(strings)
 
     return 0
 

--- a/tests/core/character/test_creation_draft.py
+++ b/tests/core/character/test_creation_draft.py
@@ -1,0 +1,39 @@
+"""Тесты черновика создания персонажа."""
+
+from pathlib import Path
+
+from core.character.creation_draft import (
+    CreationDraft,
+    clear_creation_draft,
+    has_creation_draft,
+    load_creation_draft,
+    save_creation_draft,
+)
+
+
+def test_creation_draft_save_load_clear(tmp_path: Path) -> None:
+    path = tmp_path / "creation_draft.json"
+    draft = CreationDraft(
+        current_step="stats",
+        name="Aragorn",
+        difficulty="normal",
+        race_id="human",
+        subrace_id="standard",
+    )
+    save_creation_draft(draft, path)
+    assert has_creation_draft(path) is True
+    loaded = load_creation_draft(path)
+    assert loaded is not None
+    assert loaded.current_step == "stats"
+    assert loaded.name == "Aragorn"
+    assert loaded.race_id == "human"
+    clear_creation_draft(path)
+    assert has_creation_draft(path) is False
+    assert load_creation_draft(path) is None
+
+
+def test_creation_draft_corrupt_cleared(tmp_path: Path) -> None:
+    path = tmp_path / "creation_draft.json"
+    path.write_text("{not-json", encoding="utf-8")
+    assert load_creation_draft(path) is None
+    assert not path.exists()

--- a/tests/core/character/test_creation_draft.py
+++ b/tests/core/character/test_creation_draft.py
@@ -19,6 +19,14 @@ def test_creation_draft_save_load_clear(tmp_path: Path) -> None:
         difficulty="normal",
         race_id="human",
         subrace_id="standard",
+        stats={
+            "strength": 15,
+            "dexterity": 14,
+            "constitution": 13,
+            "intelligence": 12,
+            "wisdom": 10,
+            "charisma": 8,
+        },
     )
     save_creation_draft(draft, path)
     assert has_creation_draft(path) is True
@@ -27,6 +35,8 @@ def test_creation_draft_save_load_clear(tmp_path: Path) -> None:
     assert loaded.current_step == "stats"
     assert loaded.name == "Aragorn"
     assert loaded.race_id == "human"
+    assert loaded.stats is not None
+    assert loaded.stats["strength"] == 15
     clear_creation_draft(path)
     assert has_creation_draft(path) is False
     assert load_creation_draft(path) is None
@@ -37,3 +47,25 @@ def test_creation_draft_corrupt_cleared(tmp_path: Path) -> None:
     path.write_text("{not-json", encoding="utf-8")
     assert load_creation_draft(path) is None
     assert not path.exists()
+
+
+def test_creation_draft_rejects_short_stat_keys(tmp_path: Path) -> None:
+    path = tmp_path / "creation_draft.json"
+    draft = CreationDraft(
+        current_step="background",
+        name="Hero",
+        difficulty="normal",
+        race_id="human",
+        stats={
+            "str": 15,
+            "dex": 14,
+            "con": 13,
+            "int": 12,
+            "wis": 10,
+            "cha": 8,
+        },
+    )
+    save_creation_draft(draft, path)
+    loaded = load_creation_draft(path)
+    assert loaded is not None
+    assert loaded.stats is None

--- a/tests/ui/test_menus_main.py
+++ b/tests/ui/test_menus_main.py
@@ -29,7 +29,23 @@ def test_show_main_menu_includes_mods_item(
     patch_int_input: Any,
 ) -> None:
     patch_int_input(monkeypatch, [6])
-    assert main_menu.show_main_menu(ru_strings) == 6
+    assert main_menu.show_main_menu(ru_strings) == "mods"
+
+
+def test_show_main_menu_continue_when_draft(
+    monkeypatch: pytest.MonkeyPatch,
+    ru_strings: dict[str, Any],
+    patch_int_input: Any,
+) -> None:
+    patch_int_input(monkeypatch, [1])
+    assert (
+        main_menu.show_main_menu(ru_strings, has_creation_draft=True)
+        == "continue"
+    )
+    patch_int_input(monkeypatch, [7])
+    assert (
+        main_menu.show_main_menu(ru_strings, has_creation_draft=True) == "mods"
+    )
 
 
 def test_select_difficulty_back_and_hardcore(
@@ -66,3 +82,19 @@ def test_input_handler_validation(
     assert (
         get_str_input("name: ", min_length=2, only_letters=True) == "Aragorn"
     )
+
+
+def test_safe_input_ignores_keyboard_interrupt(
+    monkeypatch: pytest.MonkeyPatch, capsys: Any, ru_strings: dict[str, Any]
+) -> None:
+    calls = {"n": 0}
+
+    def _input(_prompt: str) -> str:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise KeyboardInterrupt
+        return "3"
+
+    monkeypatch.setattr("builtins.input", _input)
+    assert get_int_input("test: ", 0, 5, ru_strings) == 3
+    assert "Ctrl+C" in capsys.readouterr().out

--- a/ui/input_handler.py
+++ b/ui/input_handler.py
@@ -43,6 +43,26 @@ def _error(
     return default.format(**kwargs)
 
 
+def _print_ctrl_c_ignored(strings: StringsDict | None) -> None:
+    """Сообщение: Ctrl+C игнорируется."""
+    msg = _error(
+        strings,
+        "errors.ctrl_c_ignored",
+        "Ctrl+C отключён. Для выхода используйте меню.",
+    )
+    print(f"{Fore.YELLOW}{msg}{Style.RESET_ALL}")
+
+
+def safe_input(prompt: str, strings: StringsDict | None = None) -> str:
+    """Прочитать строку; Ctrl+C не прерывает — повтор prompt."""
+    while True:
+        try:
+            return input(prompt)
+        except KeyboardInterrupt:
+            print()
+            _print_ctrl_c_ignored(strings)
+
+
 def get_int_input(
     prompt: str,
     min_val: int,
@@ -57,7 +77,7 @@ def get_int_input(
     """
     while True:
         try:
-            raw = input(f"{Fore.CYAN}{prompt}{Style.RESET_ALL}")
+            raw = safe_input(f"{Fore.CYAN}{prompt}{Style.RESET_ALL}", strings)
             if not raw.strip():
                 if default is not None and min_val <= default <= max_val:
                     return default
@@ -92,7 +112,7 @@ def get_str_input(
 ) -> str:
     """Запросить строку минимальной длины."""
     while True:
-        raw = input(f"{Fore.CYAN}{prompt}{Style.RESET_ALL}")
+        raw = safe_input(f"{Fore.CYAN}{prompt}{Style.RESET_ALL}", strings)
         value = raw.strip()
 
         if only_letters and not value.isalpha():

--- a/ui/menus/__init__.py
+++ b/ui/menus/__init__.py
@@ -1,6 +1,9 @@
 """Публичный API экранов меню."""
 
-from ui.menus.creation.steps import show_create_character_flow
+from ui.menus.creation.steps import (
+    show_continue_character_flow,
+    show_create_character_flow,
+)
 from ui.menus.hub.characters_menu import show_characters_menu
 from ui.menus.hub.load_game import show_load_game_flow
 from ui.menus.hub.main_menu import show_main_menu, show_welcome_screen
@@ -15,6 +18,7 @@ from ui.menus.stats import show_stats_generation_flow
 
 __all__ = [
     "select_difficulty",
+    "show_continue_character_flow",
     "show_create_character_flow",
     "show_characters_menu",
     "show_languages_menu",

--- a/ui/menus/console.py
+++ b/ui/menus/console.py
@@ -7,7 +7,7 @@ from colorama import Fore, Style
 
 from core.platform.localization import get_string
 from core.types import StringsDict
-from ui.input_handler import get_int_input
+from ui.input_handler import get_int_input, safe_input
 
 SCREEN_WIDTH = 78
 SEPARATOR = f"{Fore.YELLOW}{'=' * SCREEN_WIDTH}{Style.RESET_ALL}"
@@ -26,7 +26,7 @@ def skill_name(strings: StringsDict, skill_key: str) -> str:
 def press_enter(strings: StringsDict) -> None:
     """Ожидание нажатия Enter."""
     prompt = get_string(strings, "common.press_enter")
-    input(f"{Fore.CYAN}{prompt}{Style.RESET_ALL}")
+    safe_input(f"{Fore.CYAN}{prompt}{Style.RESET_ALL}", strings)
 
 
 def confirm_yes_no(

--- a/ui/menus/creation/state.py
+++ b/ui/menus/creation/state.py
@@ -1,9 +1,10 @@
 """Состояние и типы flow создания персонажа."""
 
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any
 
 from core.character.build import build_new_character
+from core.character.creation_draft import CreationDraft, CreationStep
 from core.character.models import Character
 from core.character.storage import unique_save_slug
 from core.progression.class_progression import (
@@ -12,19 +13,11 @@ from core.progression.class_progression import (
 )
 from core.types import CharacterBuildParams, GameDifficulty, StatMap
 
-CreationStep = Literal[
-    "race",
-    "subrace",
-    "languages",
-    "stats",
-    "background",
-    "feats",
-    "class",
-    "subclass",
-    "proficiencies",
-    "skills",
-    "expertise",
-    "equipment",
+__all__ = [
+    "CreationStep",
+    "_CreationState",
+    "draft_from_state",
+    "state_from_draft",
 ]
 
 
@@ -93,3 +86,64 @@ class _CreationState:
                 unique_save_slug=unique_save_slug,
             )
         )
+
+
+def draft_from_state(
+    state: _CreationState, current_step: CreationStep
+) -> CreationDraft:
+    """Собрать черновик из UI-состояния и текущего шага."""
+    return CreationDraft(
+        current_step=current_step,
+        name=state.name,
+        difficulty=state.difficulty,
+        race_id=state.race_id,
+        subrace_id=state.subrace_id,
+        languages=state.languages,
+        stats=state.stats,
+        background_id=state.background_id,
+        background_skills=list(state.background_skills),
+        class_id=state.class_id,
+        subclass_id=state.subclass_id,
+        skills=state.skills,
+        skill_expertise=state.skill_expertise,
+        tool_expertise=state.tool_expertise,
+        weapon_proficiencies=state.weapon_proficiencies,
+        armor_proficiencies=state.armor_proficiencies,
+        tool_proficiencies=state.tool_proficiencies,
+        background_tool_picks=list(state.background_tool_picks),
+        equipment_choices=dict(state.equipment_choices),
+        feat_ids=list(state.feat_ids),
+        feat_choices={
+            key: dict(value) for key, value in state.feat_choices.items()
+        },
+        hardcore_rolls=list(state.hardcore_rolls),
+    )
+
+
+def state_from_draft(draft: CreationDraft) -> _CreationState:
+    """Восстановить UI-состояние из черновика."""
+    return _CreationState(
+        name=draft.name,
+        difficulty=draft.difficulty,
+        race_id=draft.race_id,
+        subrace_id=draft.subrace_id,
+        languages=draft.languages,
+        stats=draft.stats,
+        background_id=draft.background_id,
+        background_skills=list(draft.background_skills),
+        class_id=draft.class_id,
+        subclass_id=draft.subclass_id,
+        skills=draft.skills,
+        skill_expertise=draft.skill_expertise,
+        tool_expertise=draft.tool_expertise,
+        weapon_proficiencies=draft.weapon_proficiencies,
+        armor_proficiencies=draft.armor_proficiencies,
+        tool_proficiencies=draft.tool_proficiencies,
+        background_tool_picks=list(draft.background_tool_picks),
+        equipment_choices=dict(draft.equipment_choices),
+        feat_ids=list(draft.feat_ids),
+        feat_choices={
+            key: dict(value) for key, value in draft.feat_choices.items()
+        },
+        hardcore_rolls=list(draft.hardcore_rolls),
+    )

--- a/ui/menus/creation/steps.py
+++ b/ui/menus/creation/steps.py
@@ -77,7 +77,10 @@ def run_creation_steps(
                 clear_creation_draft()
                 return result.character
             if result.next_step is None:
-                clear_creation_draft()
+                # Осознанная отмена: state ещё нельзя собрать в Character.
+                # Неудачный finalize: state полный — черновик оставляем.
+                if state.to_character() is None:
+                    clear_creation_draft()
                 return None
             step = result.next_step
             _persist_draft(state, step)

--- a/ui/menus/creation/steps.py
+++ b/ui/menus/creation/steps.py
@@ -1,13 +1,27 @@
 """Шаги state machine создания персонажа."""
 
+from core.character.creation_draft import (
+    clear_creation_draft,
+    load_creation_draft,
+    save_creation_draft,
+)
 from core.character.models import Character
 from core.platform.localization import get_string
 from core.types import StringsDict
 from ui.input_handler import get_str_input
 from ui.menus.console import print_screen_header
 from ui.menus.creation.handlers import _STEP_HANDLERS
-from ui.menus.creation.state import CreationStep, _CreationState
+from ui.menus.creation.state import (
+    CreationStep,
+    _CreationState,
+    draft_from_state,
+    state_from_draft,
+)
 from ui.menus.hub.settings import select_difficulty
+
+
+def _persist_draft(state: _CreationState, step: CreationStep) -> None:
+    save_creation_draft(draft_from_state(state, step))
 
 
 def show_create_character_flow(
@@ -28,21 +42,45 @@ def show_create_character_flow(
     )
 
     state = _CreationState(name=name, difficulty=difficulty)
+    _persist_draft(state, "race")
     return run_creation_steps(strings, state, language)
+
+
+def show_continue_character_flow(
+    strings: StringsDict, language: str = "ru"
+) -> Character | None:
+    """Продолжить незавершённое создание персонажа."""
+    draft = load_creation_draft()
+    if draft is None:
+        return None
+    print_screen_header(get_string(strings, "character.creation_caption"))
+    state = state_from_draft(draft)
+    return run_creation_steps(
+        strings, state, language, start_step=draft.current_step
+    )
 
 
 def run_creation_steps(
     strings: StringsDict,
     state: _CreationState,
     language: str = "ru",
+    *,
+    start_step: CreationStep = "race",
 ) -> Character | None:
     """Цикл шагов создания персонажа после ввода имени."""
-    step: CreationStep = "race"
+    step: CreationStep = start_step
 
-    while True:
-        result = _STEP_HANDLERS[step](strings, state, language)
-        if result.character is not None:
-            return result.character
-        if result.next_step is None:
-            return None
-        step = result.next_step
+    try:
+        while True:
+            result = _STEP_HANDLERS[step](strings, state, language)
+            if result.character is not None:
+                clear_creation_draft()
+                return result.character
+            if result.next_step is None:
+                clear_creation_draft()
+                return None
+            step = result.next_step
+            _persist_draft(state, step)
+    except KeyboardInterrupt:
+        # Fallback: основная защита в input_handler; черновик не чистим.
+        return None

--- a/ui/menus/hub/main_menu.py
+++ b/ui/menus/hub/main_menu.py
@@ -11,6 +11,8 @@ from ui.menus.console import (
     run_numbered_menu,
 )
 
+MainMenuAction = str
+
 
 def show_welcome_screen(version: str, strings: StringsDict) -> None:
     """Показать приветственный экран."""
@@ -28,8 +30,10 @@ def show_welcome_screen(version: str, strings: StringsDict) -> None:
     print()
 
 
-def show_main_menu(strings: StringsDict) -> int:
-    """Показать главное меню и получить выбор."""
+def show_main_menu(
+    strings: StringsDict, *, has_creation_draft: bool = False
+) -> MainMenuAction:
+    """Показать главное меню и вернуть action id."""
     print(SEPARATOR)
     print(
         f"{Fore.YELLOW}"
@@ -39,14 +43,23 @@ def show_main_menu(strings: StringsDict) -> int:
     print(SEPARATOR)
     print()
 
-    options = [
-        get_string(strings, "menu.new_game"),
-        get_string(strings, "menu.load_game"),
-        get_string(strings, "menu.characters"),
-        get_string(strings, "menu.settings"),
-        get_string(strings, "menu.languages"),
-        get_string(strings, "menu.mods"),
-    ]
+    entries: list[tuple[str, str]] = []
+    if has_creation_draft:
+        entries.append(
+            ("continue", get_string(strings, "menu.continue_creation"))
+        )
+    entries.extend(
+        [
+            ("new_game", get_string(strings, "menu.new_game")),
+            ("load_game", get_string(strings, "menu.load_game")),
+            ("characters", get_string(strings, "menu.characters")),
+            ("settings", get_string(strings, "menu.settings")),
+            ("languages", get_string(strings, "menu.languages")),
+            ("mods", get_string(strings, "menu.mods")),
+        ]
+    )
+    options = [label for _, label in entries]
+    actions = [action for action, _ in entries]
 
     def _separator_before_back() -> None:
         print()
@@ -57,9 +70,9 @@ def show_main_menu(strings: StringsDict) -> int:
         options,
         prompt_key="menu.prompt",
         back_label_key="menu.exit",
-        prompt_kwargs={"max": 6},
+        prompt_kwargs={"max": len(options)},
         before_back=_separator_before_back,
     )
-    if choice is None:
-        return 0
-    return choice
+    if choice is None or choice == 0:
+        return "exit"
+    return actions[choice - 1]


### PR DESCRIPTION
## Summary
- Persist unfinished character creation to `saves/creation_draft.json` between steps and resume via a main-menu «Продолжить» / Continue item
- Ignore Ctrl+C on prompts (`safe_input`) and in the main loop so SIGINT does not abort the game; draft survives kill/terminal close
- Clear draft on successful create or intentional cancel; keep it if finalize fails with a complete build state

## Test plan
- [ ] Start character creation, complete a few steps, kill the process — relaunch and use Continue to resume at the saved step
- [ ] Finish creation successfully — Continue disappears and draft file is gone
- [ ] Cancel creation from an early step (back) — draft cleared, no Continue
- [ ] Press Ctrl+C during a prompt — hint shown, prompt continues; exit only via menu 0
- [ ] `make verify-scope` (already passed on branch)


Made with [Cursor](https://cursor.com)